### PR TITLE
fix utf8 for ruby 1.9 and ruby 2.0

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@
 #
 # Contributors:
 # - Martin Alfke
-# - Achim Ledermüller (Netways GmbH)
+# - Achim Ledermueller (Netways GmbH)
 # - Sebastian Saemann (Netways GmbH)
 #
 # === Parameters


### PR DESCRIPTION
umlaut u breaks ruby 1.9 and ruby 2.0 rake tests.
