### PR TITLE
Add a sample hook to files/hooksscripts.

### DIFF
--- a/files/hookscripts/sample_hook.py
+++ b/files/hookscripts/sample_hook.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# encoding: utf8
+
+# This is a sample hook which does nothing.
+# Please see the documentation of OpenNebula hooks
+#   http://opennebula.org/documentation:rel4.2:hooks
+
+def do_nothing():
+    pass
+
+if __name__ == '__main__':
+    do_nothing()


### PR DESCRIPTION
- As git don't track empty directories 'hookscripts' isn't in the checkout and Puppet fails with
  "Could not retrieve information from environment production source(s) puppet:///modules/one/hookscripts"
  
  Instead of adding a .gitignore file as the git faq suggests i added a sample hook with the url to the hooks  documentation.
