### PR TITLE
migrate from forked rspec-puppet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ gem "mocha", :require => false
 gem 'puppet',       '>= 3.1.1'
 gem 'puppet-lint'
 gem 'facter',       '>= 1.6.10'
-gem 'rspec-puppet', :git => "https://github.com/agx/rspec-puppet.git"
+gem 'rspec-puppet'
+gem 'hiera-puppet-helper'
 gem 'rake',         '>= 0.9.2'
 gem 'puppetlabs_spec_helper', '0.3.0'
 gem 'test-unit'

--- a/spec/classes/compute_node_spec.rb
+++ b/spec/classes/compute_node_spec.rb
@@ -1,23 +1,18 @@
 require 'spec_helper'
-require 'rspec-puppet'
-require 'hiera'
-require 'facter'
+
+
 
 configdir = '/etc/one'
 oned_config = "#{configdir}/oned.conf"
 sunstone_config = "#{configdir}/sunstone-server.conf"
-hiera_config = 'spec/fixtures/hiera/hiera.yaml'
 
 describe 'one::compute_node' do
+    include_context "hieradata"
     context "with hiera config on RedHat" do
-        let(:hiera_config) { hiera_config }
         let (:facts) { {
             :osfamily => 'RedHat'
         } }
         context 'as compute node' do
-            hiera = Hiera.new(:config => hiera_config)
-            sshprivkey = hiera.lookup("one::node::ssh_priv_key", nil, nil)
-            sshpubkey = hiera.lookup("one::node::ssh_pub_key", nil, nil)
             it { should contain_package("opennebula-node-kvm") }
             it { should contain_package("qemu-kvm") }
             it { should contain_package("libvirt") }
@@ -29,22 +24,18 @@ describe 'one::compute_node' do
             it { should contain_file("/etc/libvirt/libvirtd.conf") }
             it { should contain_file("/etc/sysconfig/libvirtd") }
             it { should contain_file("/var/lib/one/.ssh/id_dsa")\
-                .with_content(sshprivkey)
+                .with_content('ssh-dsa priv key')
             }
             it { should contain_file("/var/lib/one/.ssh/id_dsa.pub")\
-                .with_content(sshpubkey)
+                .with_content('ssh pub key')
             }
         end
     end
     context "with hiera config on Debian" do
-        let(:hiera_config) { hiera_config }
         let (:facts) { {
             :osfamily => 'Debian'
         } }
         context 'as compute node' do
-            hiera = Hiera.new(:config => hiera_config)
-            sshprivkey = hiera.lookup("one::node::ssh_priv_key", nil, nil)
-            sshpubkey = hiera.lookup("one::node::ssh_pub_key", nil, nil)
             it { should contain_package("opennebula-node") }
             it { should contain_package("qemu-kvm") }
             it { should contain_package("libvirt-bin") }
@@ -55,10 +46,10 @@ describe 'one::compute_node' do
             it { should contain_file("/etc/libvirt/libvirtd.conf") }
             it { should contain_file("/etc/default/libvirt-bin") }
             it { should contain_file("/var/lib/one/.ssh/id_dsa")\
-                .with_content(sshprivkey)
+                .with_content('ssh-dsa priv key')
             }
             it { should contain_file("/var/lib/one/.ssh/id_dsa.pub")\
-                .with_content(sshpubkey)
+                .with_content('ssh pub key')
             }
         end
     end

--- a/spec/classes/one_spec.rb
+++ b/spec/classes/one_spec.rb
@@ -7,18 +7,14 @@ configdir = '/etc/one'
 oned_config = "#{configdir}/oned.conf"
 sunstone_config = "#{configdir}/sunstone-server.conf"
 ldap_config = "#{configdir}/auth/ldap_auth.conf"
-hiera_config = 'spec/fixtures/hiera/hiera.yaml'
 
 describe 'one' do
+    include_context "hieradata"
     context "with hiera config on RedHat" do
-        let(:hiera_config) { hiera_config }
         let (:facts) { {
             :osfamily => 'RedHat'
         } }
         context 'as compute node' do
-            hiera = Hiera.new(:config => hiera_config)
-            sshprivkey = hiera.lookup("one::node::ssh_priv_key", nil, nil)
-            sshpubkey = hiera.lookup("one::node::ssh_pub_key", nil, nil)
             it { should contain_class('one') }
             it { should contain_class('one::compute_node') }
             it { should contain_package("opennebula-node-kvm") }
@@ -32,14 +28,13 @@ describe 'one' do
             it { should contain_file("/etc/libvirt/libvirtd.conf") }
             it { should contain_file("/etc/sysconfig/libvirtd") }
             it { should contain_file("/var/lib/one/.ssh/id_dsa")\
-                .with_content(sshprivkey)
+                .with_content('ssh-dsa priv key')
             }
             it { should contain_file("/var/lib/one/.ssh/id_dsa.pub")\
-                .with_content(sshpubkey)
+                .with_content('ssh pub key')
             }
         end # fin context 'as compute node'
         context 'as mgmt node' do
-            let(:hiera_config) { hiera_config }
             let (:facts) { {
                 :osfamily => 'RedHat'
             } }
@@ -48,7 +43,6 @@ describe 'one' do
                     :oned => true,
                     :backend => 'sqlite' 
                 } }
-                hiera = Hiera.new(:config => hiera_config)
                 it { should contain_class('one') }
                 it { should contain_class('one::oned') }
                 it { should contain_package("dbus") }
@@ -100,7 +94,6 @@ describe 'one' do
                     :sunstone => true,
                     :ldap => true
                 }}
-                hiera = Hiera.new(:config => hiera_config)
                 it { should contain_class('one') }
                 it { should contain_class('one::oned') }
                 it { should contain_class('one::oned::sunstone') }
@@ -126,14 +119,10 @@ describe 'one' do
         end # fin context 'as mgmt node'
     end # fin context "with hiera config on RedHat"
     context "with hiera config on Debian" do
-        let(:hiera_config) { hiera_config }
         let (:facts) { {
             :osfamily => 'Debian'
         } }
         context 'as compute node' do
-            hiera = Hiera.new(:config => hiera_config)
-            sshprivkey = hiera.lookup("one::node::ssh_priv_key", nil, nil)
-            sshpubkey = hiera.lookup("one::node::ssh_pub_key", nil, nil)
             it { should contain_class('one') }
             it { should contain_class('one::compute_node') }
             it { should contain_package("opennebula-node") }
@@ -146,14 +135,13 @@ describe 'one' do
             it { should contain_file("/etc/libvirt/libvirtd.conf") }
             it { should contain_file("/etc/default/libvirt-bin") }
             it { should contain_file("/var/lib/one/.ssh/id_dsa")\
-                .with_content(sshprivkey)
+                .with_content('ssh-dsa priv key')
             }
             it { should contain_file("/var/lib/one/.ssh/id_dsa.pub")\
-                .with_content(sshpubkey)
+                .with_content('ssh pub key')
             }
         end # fin context 'as compute node'
         context 'as mgmt node' do
-            let(:hiera_config) { hiera_config }
             let (:facts) { {
                 :osfamily => 'Debian'
             } }
@@ -162,7 +150,6 @@ describe 'one' do
                     :oned => true,
                     :backend => 'sqlite' 
                 } }
-                hiera = Hiera.new(:config => hiera_config)
                 it { should contain_class('one') }
                 it { should contain_class('one::oned') }
                 it { should contain_package("dbus") }
@@ -212,7 +199,6 @@ describe 'one' do
                     :sunstone => true,
                     :ldap => true
                 }}
-                hiera = Hiera.new(:config => hiera_config)
                 it { should contain_class('one') }
                 it { should contain_class('one::oned') }
                 it { should contain_class('one::oned::sunstone') }

--- a/spec/classes/oned_spec.rb
+++ b/spec/classes/oned_spec.rb
@@ -6,11 +6,10 @@ require 'facter'
 configdir = '/etc/one'
 oned_config = "#{configdir}/oned.conf"
 sunstone_config = "#{configdir}/sunstone-server.conf"
-hiera_config = 'spec/fixtures/hiera/hiera.yaml'
 
 describe 'one::oned' do
+    include_context "hieradata"
     context "with hiera config on RedHat" do
-        let(:hiera_config) { hiera_config }
         let (:facts) { {
             :osfamily => 'RedHat'
         } }
@@ -19,7 +18,6 @@ describe 'one::oned' do
                 :backend => 'sqlite',
                 :ldap => false
             } }
-            hiera = Hiera.new(:config => hiera_config)
             it { should contain_package("dbus") }
             it { should contain_package("opennebula") }
             it { should contain_package("opennebula-server") }
@@ -45,7 +43,6 @@ describe 'one::oned' do
         end
     end
     context "with hiera config on Debian" do
-        let(:hiera_config) { hiera_config }
         let (:facts) { {
             :osfamily => 'Debian'
         } }
@@ -54,7 +51,6 @@ describe 'one::oned' do
                 :backend => 'sqlite',
                 :ldap => false
             } }
-            hiera = Hiera.new(:config => hiera_config)
             it { should contain_package("dbus") }
             it { should contain_package("opennebula") }
             it { should contain_package("ruby-opennebula") }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'test/unit'
 require 'mocha/setup'
-require 'rspec-puppet'
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'hiera-puppet-helper'
 
 fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
 
@@ -15,3 +15,14 @@ RSpec.configure do |c|
   c.manifest_dir = File.join(fixture_path, 'manifests')
   c.mock_with :mocha
 end
+
+shared_context "hieradata" do
+  let(:hiera_config) do
+    { :backends => ['rspec', 'yaml'],
+      :hierarchy => [ 'test' ],
+      :yaml => {
+        :datadir => File.join(fixture_path, 'hiera') },
+      :rspec => respond_to?(:hiera_data) ? hiera_data : {} }
+  end
+end
+


### PR DESCRIPTION
we want to use default rspec-puppet
we make use of hiera-puppet-helper
 (https://github.com/mthibaut/hiera-puppet-helper)

which is the replacement.
(also see https://github.com/rodjek/rspec-puppet/pull/91)
