### PR TITLE
reduce defined packages

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,13 +38,7 @@ class one::params {
   # params for nodes
   case $::osfamily {
     'RedHat': {
-      $node_packages = ['libvirt',
-                        'qemu-kvm',
-                        'bridge-utils',
-                        'vconfig',
-                        'opennebula-node-kvm',
-                        'sudo',
-                        ]
+      $node_packages = 'opennebula-node-kvm'
       $oned_packages   = ['opennebula', 'opennebula-server', 'opennebula-ruby']
       $dbus_srv        = 'messagebus'
       $dbus_pkg        = 'dbus'
@@ -62,12 +56,7 @@ class one::params {
       $libvirtd_source = 'puppet:///modules/one/libvirtd.sysconfig'
     }
     'Debian': {
-      $node_packages   = ['libvirt-bin',
-                          'qemu-kvm',
-                          'bridge-utils',
-                          'opennebula-node',
-                          'sudo',
-                          ]
+      $node_packages   = 'opennebula-node'
       $oned_packages   = ['opennebula', 'opennebula-tools', 'ruby-opennebula']
       $dbus_srv        = 'dbus'
       $dbus_pkg        = 'dbus'

--- a/spec/classes/compute_node_spec.rb
+++ b/spec/classes/compute_node_spec.rb
@@ -15,11 +15,6 @@ describe 'one::compute_node' do
             hiera = Hiera.new(:config => hiera_config)
             sshpubkey = hiera.lookup('one::head::ssh_pub_key', nil, nil)
             it { should contain_package('opennebula-node-kvm') }
-            it { should contain_package('qemu-kvm') }
-            it { should contain_package('libvirt') }
-            it { should contain_package('bridge-utils') }
-            it { should contain_package('vconfig') }
-            it { should contain_package('sudo') }
             it { should contain_group('oneadmin') }
             it { should contain_user('oneadmin') }
             it { should contain_file('/etc/libvirt/libvirtd.conf') }
@@ -48,10 +43,6 @@ describe 'one::compute_node' do
             hiera = Hiera.new(:config => hiera_config)
             sshpubkey = hiera.lookup('one::head::ssh_pub_key', nil, nil)
             it { should contain_package('opennebula-node') }
-            it { should contain_package('qemu-kvm') }
-            it { should contain_package('libvirt-bin') }
-            it { should contain_package('bridge-utils') }
-            it { should contain_package('sudo') }
             it { should contain_group('oneadmin') }
             it { should contain_user('oneadmin') }
             it { should contain_file('/etc/libvirt/libvirtd.conf') }

--- a/spec/classes/one_spec.rb
+++ b/spec/classes/one_spec.rb
@@ -21,11 +21,6 @@ describe 'one' do
             it { should contain_class('one') }
             it { should contain_class('one::compute_node') }
             it { should contain_package('opennebula-node-kvm') }
-            it { should contain_package('qemu-kvm') }
-            it { should contain_package('libvirt') }
-            it { should contain_package('bridge-utils') }
-            it { should contain_package('vconfig') }
-            it { should contain_package('sudo') }
             it { should contain_group('oneadmin') }
             it { should contain_user('oneadmin') }
             it { should contain_file('/etc/libvirt/libvirtd.conf') }
@@ -140,10 +135,6 @@ describe 'one' do
             it { should contain_class('one') }
             it { should contain_class('one::compute_node') }
             it { should contain_package('opennebula-node') }
-            it { should contain_package('qemu-kvm') }
-            it { should contain_package('libvirt-bin') }
-            it { should contain_package('bridge-utils') }
-            it { should contain_package('sudo') }
             it { should contain_group('oneadmin') }
             it { should contain_user('oneadmin') }
             it { should contain_file('/etc/libvirt/libvirtd.conf') }


### PR DESCRIPTION
As we have vconfig defined in our base-class used by all servers, we ran into an error. However, the opennebula-node-kvm RPMs already depend on those packages, so this should be no problem.
