### PR TITLE
Fix context RPM name to newer one - version 4.2.1

### DIFF
--- a/templates/kickstart.ks.erb
+++ b/templates/kickstart.ks.erb
@@ -40,7 +40,7 @@ repo --name="context" --baseurl=<%= @ohd_repo_puppet %>
 puppet
 ntp
 ntpdate
-opennebula-context
+one-context
 
 %post --log=/root/post-install.log
 rm -v /etc/yum.repos.d/CentOS-*


### PR DESCRIPTION
rename context RPM in kickstart for newer name of newer RPM
