### PR TITLE
preseed_config

### DIFF
--- a/templates/preseed.cfg.erb
+++ b/templates/preseed.cfg.erb
@@ -65,7 +65,8 @@ d-i pkgsel/include string \
               ntpdate \
               openssh-server \
               one-context \
-              puppet
+              puppet \
+              ruby-hiera-puppet
 
 popularity-contest popularity-contest/participate boolean false
 


### PR DESCRIPTION
This changes deletes the dhcp client package and adds hiera support in debian installations.
