### PR TITLE
Add another CentOS5 workaround

### DIFF
--- a/templates/kickstart.ks.erb
+++ b/templates/kickstart.ks.erb
@@ -50,5 +50,5 @@ rm -v /etc/yum.repos.d/CentOS-*
 # for ONEs contextualization via /dev/disk/by-label/CONTEXT
 if [ -f /etc/udev/rules.d/50-udev.rules ]; then
   sed -i 's/^KERNEL==".*, SYSFS{removable}=="1", GOTO="persistent_end"$//' /etc/udev/rules.d/50-udev.rules
-  echo '/sbin/blkid /dev/disk/by-label/CONTEXT' >> /etc/rc.local
+  sed -i 's,mount -t iso9660 -L CONTEXT,mount -t iso9660 /dev/disk/by-label/CONTEXT,' /etc/init.d/vmcontext
 fi


### PR DESCRIPTION
rc.local runs too late so instead of working arounds mount's -L
brokeness simply use the mount point the init script checks for antways.
