### PR TITLE
Add 'acpid' to the packages section in kickstarttemplate.

### DIFF
--- a/templates/kickstart.ks.erb
+++ b/templates/kickstart.ks.erb
@@ -42,6 +42,7 @@ repo --name="<%= k %>" --baseurl=<%= v['url'] %>
 puppet
 ntp
 one-context
+acpid
 <% pkgs = (@data[@name] || {})['pkgs'] || []
 pkgs.each do |p| -%>
 <%= p %>


### PR DESCRIPTION
- As libvirt uses acpi events to shutdown / reboot domains acpid must be
  installed in the vm.
