### PR TITLE
prepare to make use of implicit hiera lookups

### DIFF
--- a/spec/classes/opennebula_rhel_spec.rb
+++ b/spec/classes/opennebula_rhel_spec.rb
@@ -6,6 +6,12 @@ require 'facter'
 hiera_config = 'spec/fixtures/hiera/hiera.yaml'
 
 describe 'one' do
+  context 'with default params as implicit hiera lookup' do
+    let (:facts) { {:osfamily => 'RedHat'} }
+    it { should contain_class('one') }
+    it { should_not contain_file('/etc/one/oned.conf').with_content(/^DB = \[ backend = \"sqlite\"/) }
+    it { should_not contain_class('one::oned') }
+  end
   let(:hiera_config) { hiera_config }
   context 'with hiera config on RedHat' do
     let (:facts) { {:osfamily => 'RedHat'} }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ Dir[support_path].each { |f| require f }
 RSpec.configure do |c|
   c.config = '/doesnotexist'
   c.manifest_dir = File.join(fixture_path, 'manifests')
+  c.hiera_config = File.join(fixture_path, 'hiera/hiera.yaml')
   c.mock_with :mocha
 end
 


### PR DESCRIPTION
Using hiera_config in Rspec.configure allows to make use of implicit hiera lookups.
This allows improved testing by adding hiera data only without the need to explicit hiera calls.
