### PR TITLE
Fix broken i/o redirection

### DIFF
--- a/files/imaginator
+++ b/files/imaginator
@@ -50,8 +50,8 @@ sudo -u oneadmin virt-install \
 
     # virbr0 cleanup
     if [ $bridge == 'virbr0' ]; then
-        service dnsmasq stop 1> /dev/null 2> &1
-        brctl delbr virbr0  1> /dev/null 2> &1
+        service dnsmasq stop 1> /dev/null 2>&1
+        brctl delbr virbr0  1> /dev/null 2>&1
     fi
 }
 


### PR DESCRIPTION
- An i/o redirection is broken (one superfluous whitespace) which leads
  to a syntax error when running the "imaginator" script:
  
  ```
    dest@think:~$ bin/imaginator 
    bin/imaginator: line 53: syntax error near unexpected token `&'
    bin/imaginator: line 53: `        service dnsmasq stop 1> /dev/null 2> &1'
  ```
