### PR TITLE
Remove --nobase flag from kickstart file

### DIFF
--- a/templates/kickstart.ks.erb
+++ b/templates/kickstart.ks.erb
@@ -37,7 +37,7 @@ repos.each do |k,v| -%>
 repo --name="<%= k %>" --baseurl=<%= v['url'] %>
 <% end -%>
 
-%packages --nobase
+%packages
 @core
 puppet
 ntp


### PR DESCRIPTION
It might be better to have more packages.
Such as rsync, bzip, ...
