### PR TITLE
Use hash parameters in onetemplate type

### DIFF
--- a/lib/puppet/provider/onetemplate/cli.rb
+++ b/lib/puppet/provider/onetemplate/cli.rb
@@ -21,51 +21,58 @@ Puppet::Type.type(:onetemplate).provide(:cli) do
   <CPU><%=    resource[:cpu]    %></CPU>
   <VCPU><%=   resource[:vcpu]   %></VCPU>
 
+<% if resource[:os] %>
   <OS>
-<% if resource[:os_kernel]     %>    <KERNEL><%=     resource[:os_kernel]     %></KERNEL><% end %>
-<% if resource[:os_initrd]     %>    <INITRD><%=     resource[:os_initrd]     %></INITRD><% end %>
-<% if resource[:os_arch]       %>    <ARCH><%=       resource[:os_arch]       %></ARCH><% end %>
-<% if resource[:os_root]       %>    <ROOT><%=       resource[:os_root]       %></ROOT><% end %>
-<% if resource[:os_kernel_cmd] %>    <KERNEL_CMD><%= resource[:os_kernel_cmd] %></KERNEL_CMD><% end %>
-<% if resource[:os_bootloader] %>    <BOOTLOADER><%= resource[:os_bootloader] %></BOOTLOADER><% end %>
-<% if resource[:os_boot]       %>    <BOOT><%=       resource[:os_boot]       %></BOOT><% end %>
+    <% resource[:os].each do |key, value| %>
+    <<%= key.upcase %>><%= value %></<%= key.upcase %>>
+    <% end %>
   </OS>
+<% end %>
 
+<% if resource[:disks] %>
 <% resource[:disks].each do |disk| %>
   <DISK>
-    <IMAGE><%= disk %></IMAGE>
+    <% disk.each do |key, value| %>
+    <<%= key.upcase %>><%= value %></<%= key.upcase %>>
+    <% end %>
   </DISK>
 <% end %>
-<% resource[:nics].each do |nic| %>
-  <NIC>
-    <% if resource[:nic_model] %><MODEL><%= resource[:nic_model] %></MODEL><% end %>
-    <NETWORK><%= nic %></NETWORK>
-  </NIC>
 <% end %>
 
+<% if resource[:nics] %>
+<% resource[:nics].each do |nic| %>
+  <NIC>
+    <% nic.each do |key, value| %>
+    <<%= key.upcase %>><%= value %></<%= key.upcase %>>
+    <% end %>
+  </NIC>
+<% end %>
+<% end %>
+
+<% if resource[:graphics] %>
   <GRAPHICS>
-<% if resource[:graphics_type]   %><TYPE><%=   resource[:graphics_type]   %></TYPE><% end %>
-<% if resource[:graphics_listen] %><LISTEN><%= resource[:graphics_listen] %></LISTEN><% end %>
-<% if resource[:graphics_port]   %><PORT><%=   resource[:graphics_port]   %></PORT><% end %>
-<% if resource[:graphics_passwd] %><PASSWD><%= resource[:graphics_passwd] %></PASSWD><% end %>
-<% if resource[:graphics_keymap] %><KEYMAP><%= resource[:graphics_keymap] %></KEYMAP><% end %>
+    <% resource[:graphics].each do |key, value| %>
+    <<%= key.upcase %>><%= value %></<%= key.upcase %>>
+    <% end %>
   </GRAPHICS>
+<% end %>
+
+<% if resource[:features] %>
   <FEATURES>
-<% if resource[:acpi] %><ACPI><%= resource[:acpi] %></ACPI><% end %>
-<% if resource[:pae]  %><PAE><%=  resource[:pae]  %></PAE><%  end %>
+    <% resource[:features].each do |key, value| %>
+    <<%= key.upcase %>><%= value %></<%= key.upcase %>>
+    <% end %>
   </FEATURES>
-  <CONTEXT>
-<% if resource[:context_network] %><NETWORK><%= resource[:context_network] %></NETWORK><% end %>
-<% if resource[:context_files] %>
-    <FILES_DS><% resource[:context_files].each do |context_file| %>$FILE[IMAGE="<%= context_file %>"] <% end %></FILES_DS>
 <% end %>
+
 <% if resource[:context] %>
-<% resource[:context].each do |key, value| %>
-   <<%= key %>><%= value %></<%= key %>>
-<% end %>
-<% end %>
-<% if resource[:context_ssh_pubkey] %><SSH_PUBLIC_KEY><%= resource[:context_ssh_pubkey] %></SSH_PUBLIC_KEY><% end %>
+  <CONTEXT>
+    <% resource[:context].each do |key, value| %>
+    <<%= key.upcase %>><%= value %></<%= key.upcase %>>
+    <% end %>
   </CONTEXT>
+<% end %>
+
 </TEMPLATE>
 EOF
 
@@ -94,39 +101,17 @@ EOF
     REXML::Document.new(onetemplate('list', '-x')).elements.collect("VMTEMPLATE_POOL/VMTEMPLATE") do |template|
       elements = template.elements
       new(
-        :name                      => elements["NAME"].text,
-        :ensure                    => :present,
-        :acpi                      => (elements["TEMPLATE/FEATURES/ACPI"].text unless elements["TEMPLATE/FEATURES/ACPI"].nil?),
-        :context                   => (elements["TEMPLATE/CONTEXT"].text unless elements["TEMPLATE/CONTEXT"].nil?),
-        :context_files             => (elements["TEMPLATE/CONTEXT/FILES_DS"].text.to_a unless elements["TEMPLATE/CONTEXT/FILES_DS"].nil?),
-        :context_network           => (elements["TEMPLATE/CONTEXT/NETWORK"].text unless elements["TEMPLATE/CONTEXT/NETWORK"].nil?),
-        :context_onegate           => (elements["TEMPLATE/CONTEXT/ONEGATE"].text unless elements["TEMPLATE/CONTEXT/ONEGATE"].nil?),
-        :context_placement_cluster => (elements["TEMPLATE/CONTEXT/PLACEMENT/CLUSTER"].text unless elements["TEMPLATE/CONTEXT/PLACEMENT/CLUSTER"].nil?),
-        :context_placement_host    => (elements["TEMPLATE/CONTEXT/PLACEMENT/HOST"].text unless elements["TEMPLATE/CONTEXT/PLACEMENT/HOST"].nil?),
-        :context_policy            => (elements["TEMPLATE/CONTEXT/POLICY"].text unless elements["TEMPLATE/CONTEXT/POLICY"].nil?),
-        :context_ssh               => (elements["TEMPLATE/CONTEXT/SSH"].text unless elements["TEMPLATE/CONTEXT/SSH"].nil?),
-        :context_ssh_pubkey        => (elements["TEMPLATE/CONTEXT/SSH_PUBLIC_KEY"].text unless elements["TEMPLATE/CONTEXT/SSH_PUBLIC_KEY"].nil?),
-        :context_variables         => (elements["TEMPLATE/CONTEXT/VARIABLES"].text unless elements["TEMPLATE/CONTEXT/VARIABLES"].nil?),
-        :cpu                       => (elements["TEMPLATE/CPU"].text unless elements["TEMPLATE/CPU"].nil?),
-        :disks                     => elements.collect("TEMPLATE/DISK/IMAGE") { |image| image.text },
-        :graphics_keymap           => (elements["TEMPLATE/GRAPHICS/KEYMAP"].text unless elements["TEMPLATE/GRAPHICS/KEYMAP"].nil?),
-        :graphics_listen           => (elements["TEMPLATE/GRAPHICS/LISTEN"].text unless elements["TEMPLATE/GRAPHICS/LISTEN"].nil?),
-        :graphics_passwd           => (elements["TEMPLATE/GRAPHICS/PASSWORD"].text unless elements["TEMPLATE/GRAPHICS/PASSWORD"].nil?),
-        :graphics_port             => (elements["TEMPLATE/GRAPHICS/PORT"].text unless elements["TEMPLATE/GRAPHICS/PORT"].nil?),
-        :graphics_type             => (elements["TEMPLATE/GRAPHICS/TYPE"].text unless elements["TEMPLATE/GRAPHICS/TYPE"].nil?),
-        :memory                    => (elements["TEMPLATE/MEMORY"].text unless elements["TEMPLATE/MEMORY"].nil?),
-        :nic_model                 => (elements["TEMPLATE/NIC/MODEL"].text unless elements["TEMPLATE/NIC/MODEL"].nil?),
-        :nics                      => elements.collect("TEMPLATE/NIC/NETWORK") { |nic| nic.text },
-        :os_arch                   => (elements["TEMPLATE/OS/ARCH"].text unless elements["TEMPLATE/OS/ARCH"].nil?),
-        :os_boot                   => (elements["TEMPLATE/OS/BOOT"].text unless elements["TEMPLATE/OS/BOOT"].nil?),
-        :os_bootloader             => (elements["TEMPLATE/OS/BOOTLOADER"].text unless elements["TEMPLATE/OS/BOOTLOADER"].nil?),
-        :os_initrd                 => (elements["TEMPLATE/OS/INITRD"].text unless elements["TEMPLATE/OS/INITRD"].nil?),
-        :os_kernel                 => (elements["TEMPLATE/OS/KERNEL"].text unless elements["TEMPLATE/OS/KERNEL"].nil?),
-        :os_kernel_cmd             => (elements["TEMPLATE/OS/KERNEL_CMD"].text unless elements["TEMPLATE/OS/KERNEL_CMD"].nil?),
-        :os_root                   => (elements["TEMPLATE/OS/ROOT"].text unless elements["TEMPLATE/OS/ROOT"].nil?),
-        :pae                       => (elements["TEMPLATE/FEATURES/PAE"].text unless elements["TEMPLATE/FEATURES/PAE"].nil?),
-        :pci_bridge                => (elements["TEMPLATE/FEATURES/PCI_BRIDGE"].text unless elements["TEMPLATE/FEATURES/PCI_BRIDGE"].nil?),
-        :vcpu                      => (elements["TEMPLATE/VCPU"].text unless elements["TEMPLATE/VCPU"].nil?)
+        :name     => elements["NAME"].text,
+        :ensure   => :present,
+        :context  => Hash[elements.collect('TEMPLATE/CONTEXT/*') { |e| [e.name.downcase, e.text] } ],
+        :cpu      => (elements["TEMPLATE/CPU"].text unless elements["TEMPLATE/CPU"].nil?),
+        :disks    => elements.collect("TEMPLATE/DISK") { |e| Hash[e.elements.collect { |f| [f.name.downcase, f.text] }] },
+        :features => Hash[elements.collect('TEMPLATE/FEATURES/*') { |e| [e.name.downcase, { e.text => e.text, 'true' => true, 'false' => false }[e.text]] } ],
+        :graphics => Hash[elements.collect('TEMPLATE/GRAPHICS/*') { |e| [e.name.downcase, e.text] } ],
+        :memory   => (elements["TEMPLATE/MEMORY"].text unless elements["TEMPLATE/MEMORY"].nil?),
+        :nics     => elements.collect("TEMPLATE/NIC") { |e| Hash[e.elements.collect { |f| [f.name.downcase, f.text] }] },
+        :os       => Hash[elements.collect('TEMPLATE/OS/*') { |e| [e.name.downcase, e.text] } ],
+        :vcpu     => (elements["TEMPLATE/VCPU"].text unless elements["TEMPLATE/VCPU"].nil?)
       )
     end
   end
@@ -140,98 +125,17 @@ EOF
     end
   end
 
-  # setters
-  def memory=(value)
-      raise "Can not yet modify memory on a template"
+  def flush
+    file = Tempfile.new('onevnet')
+    file << @property_hash.map { |k, v|
+      unless resource[k].nil? or resource[k].to_s.empty? or [:name, :provider, :ensure].include?(k)
+        [ k.to_s.upcase, v ]
+      end
+    }.map{|a| "#{a[0]} = #{a[1]}" unless a.nil? }.join("\n")
+    file.close
+    self.debug(IO.read file.path)
+    onetemplate('update', resource[:name], file.path, '--append') unless @property_hash.empty?
+    file.delete
   end
-  def cpu=(value)
-      raise "Can not yet modify cpu on a template"
-  end
-  def vcpu=(value)
-      raise "Can not yet modify vcpu on a template"
-  end
-  def os_kernel=(value)
-      raise "Can not modify kernel on a template"
-  end
-  def os_initrd=(value)
-      raise "Can not modify initrd on a template"
-  end
-  def os_arch=(value)
-      raise "Can not modify arch on a template"
-  end
-  def os_root=(value)
-      raise "Can not modify root device on a template"
-  end
-  def os_kernel_cmd=(value)
-      raise "Can not modify kernel cmd on a template"
-  end
-  def os_bootloader=(value)
-      raise "Can not modify booloader options on a template"
-  end
-  def os_boot=(value)
-      raise "Can not modify boot device on a template"
-  end
-  def acpi=(value)
-      raise "Can not modify acpi on a template"
-  end
-  def pae=(value)
-      raise "Can not modify pae on a template"
-  end
-  def pci_bridge=(value)
-      raise "Can not modify pci_bridge on a template"
-  end
-  def disks=(value)
-      raise "Can not yet modify disks on a template"
-  end
-  def nics=(value)
-      #raise "Can not yet modify networks on a template"
-  end
-  def nic_model=(value)
-      raise "Can not modify network model on a template"
-  end
-  def graphics_type=(value)
-      raise "Can not modify graphics type on a template"
-  end
-  def graphics_listen=(value)
-      raise "Can not yet modify graphics listen port on a template"
-  end
-  def graphics_port=(value)
-      raise "Can not modify graphics_port on a template"
-  end
-  def grahics_passwd=(value)
-      raise "Can not yet modify graphics password on a template"
-  end
-  def graphics_keymap=(value)
-      raise "Can not yet modify graphics keymap on a template"
-  end
-  def context=(value)
-      #raise "Can not yet modify context hashes on a template"
-  end
-  def context_ssh=(value)
-      raise "Can not yet modify ssh context on a template"
-  end
-  def context_ssh_pubkey=(value)
-      raise "Can not yet modify root ssh pub key context on a template"
-  end
-  def context_network=(value)
-      raise "Can not yet modify network context on a template"
-  end
-  def context_onegate=(value)
-      raise "Can not modify onegate context on a template"
-  end
-  def context_files=(value)
-      #raise "Can not yet modify context files on a template"
-  end
-  def context_variables=(value)
-      raise "Can not yet modify context variables on a template"
-  end
-  def context_placement_host=(value)
-      raise "Can not yet modify host placement context on a template"
-  end
-  def context_placement_cluster=(value)
-      raise "Can not yet modify cluster placement context on a template"
-  end
-  def context_policy=(value)
-      raise "Can not yet modify placement policy context on a template"
-  end
+
 end

--- a/lib/puppet/type/onetemplate.rb
+++ b/lib/puppet/type/onetemplate.rb
@@ -4,11 +4,11 @@ Puppet::Type.newtype(:onetemplate) do
 
   ensurable
 
-  # General template config
+  # Capacity Section
   newparam(:name, :namevar => true) do
     desc "Name of template."
     validate do |value|
-        fail("Invalid name: #{value}") unless value =~ /^([A-Za-z]).*/
+      fail("Invalid name: #{value}") unless value =~ /^([A-Za-z]).*/
     end
   end
 
@@ -25,139 +25,438 @@ Puppet::Type.newtype(:onetemplate) do
     desc "Virtual CPUs"
   end
 
+  # OS and Boot Options Section
+  newproperty(:os) do
+    desc "A hash for OS and Boot Options Section"
+    defaultto {}
+    validate do |value|
+      # TODO: validate each key
+      valid_keys = [
+        'arch',
+        'machine',
+        'kernel',
+        'kernel_ds',
+        'initrd',
+        'initrd_ds',
+        'root',
+        'kernel_cmd',
+        'bootloader',
+        'boot',
+      ]
+      fail "#{(value.keys - valid_keys).join(' and ')} is not one of #{valid_keys.join(' or ')}" unless (value.keys - valid_keys).empty?
+    end
+  end
+
   # OS booting template config
   # Kernel section
   newproperty(:os_kernel) do
     desc "Path to the OS kernel to boot the template. Required in Xen."
+    validate do |value|
+      Puppet.deprecation_warning('os_kernel is deprecated, please use os hash instead.')
+    end
+    munge do |value|
+      resource[:os] ||= {}
+      resource[:os]['kernel'] = value
+      nil
+    end
   end
 
   # Ramdisk section
   newproperty(:os_initrd) do
     desc "Path to the initrd image."
+    validate do |value|
+      Puppet.deprecation_warning('os_initrd is deprecated, please use os hash instead.')
+    end
+    munge do |value|
+      resource[:os] ||= {}
+      resource[:os]['initrd'] = value
+      nil
+    end
   end
 
   # Boot section
   newproperty(:os_arch) do
     desc "CPU architecture."
+    validate do |value|
+      Puppet.deprecation_warning('os_arch is deprecated, please use os hash instead.')
+    end
+    munge do |value|
+      resource[:os] ||= {}
+      resource[:os]['arch'] = value
+      nil
+    end
   end
 
   newproperty(:os_root) do
     desc "Device to be mounted as root."
+    validate do |value|
+      Puppet.deprecation_warning('os_root is deprecated, please use os hash instead.')
+    end
+    munge do |value|
+      resource[:os] ||= {}
+      resource[:os]['root'] = value
+      nil
+    end
   end
 
   newproperty(:os_kernel_cmd) do
     desc "Arguments for the booting kernel."
+    validate do |value|
+      Puppet.deprecation_warning('os_kernel_cmd is deprecated, please use os hash instead.')
+    end
+    munge do |value|
+      resource[:os] ||= {}
+      resource[:os]['kernel_cmd'] = value
+      nil
+    end
   end
 
   newproperty(:os_bootloader) do
     desc "Path to the bootloader executable."
+    validate do |value|
+      Puppet.deprecation_warning('os_bootloader is deprecated, please use os hash instead.')
+    end
+    munge do |value|
+      resource[:os] ||= {}
+      resource[:os]['bootloader'] = value
+      nil
+    end
   end
 
   newproperty(:os_boot) do
     desc "Boot device type: hd,fd,cdrom,network"
+    validate do |value|
+      Puppet.deprecation_warning('os_boot is deprecated, please use os hash instead.')
+    end
+    munge do |value|
+      resource[:os] ||= {}
+      resource[:os]['boot'] = value
+      nil
+    end
+  end
+
+  # Features Section
+  newproperty(:features) do
+    desc "A hash for Features Section"
+    defaultto {}
+    validate do |value|
+      # TODO: validate each key
+      valid_keys = [
+        'pae',
+        'acpi',
+        'apic',
+        'localtime',
+        'hyperv',
+        'device_mode',
+        'pci_bridge',
+      ]
+      fail "#{(value.keys - valid_keys).join(' and ')} is not one of #{valid_keys.join(' or ')}" unless (value.keys - valid_keys).empty?
+    end
   end
 
   # Features section
   newproperty(:acpi, :boolean => true) do
     desc "Enable ACPI"
     newvalues(:true, :false)
+    validate do |value|
+      Puppet.deprecation_warning('acpi is deprecated, please use features hash instead.')
+    end
+    munge do |value|
+      resource[:features] ||= {}
+      resource[:features]['acpi'] = value
+      nil
+    end
   end
 
   newproperty(:pae, :boolean => true) do
     desc "Enable PAE"
     newvalues(:true, :false)
+    validate do |value|
+      Puppet.deprecation_warning('pae is deprecated, please use features hash instead.')
+    end
+    munge do |value|
+      resource[:features] ||= {}
+      resource[:features]['pae'] = value
+      nil
+    end
   end
 
   newproperty(:pci_bridge, :boolean => true) do
     desc "PCI Bridging"
     newvalues(:true, :false)
+    validate do |value|
+      Puppet.deprecation_warning('pci_bridge is deprecated, please use features hash instead.')
+    end
+    munge do |value|
+      resource[:features] ||= {}
+      resource[:features]['pci_bridge'] = value
+      nil
+    end
   end
 
-  # Template Storage config
+  # Disks Section
   newproperty(:disks, :array_matching => :all) do
-    desc "Array of disk definitions."
+    desc "An array of hash for Disks Section"
+    defaultto []
+    validate do |value|
+      if value.is_a?( Hash)
+        # TODO: validate for either persistent or volatile disk and each key
+        valid_keys = [
+          # Persistent and Clone Disks
+          'image_id',
+          'image',
+          'image_uid',
+          'image_uname',
+          'dev_prefix',
+          'target',
+          'driver',
+          'cache',
+          'readonly',
+          'io',
+          # Volatile DISKS
+          'type',
+          'size',
+          'format',
+          'dev_prefix',
+          'target',
+          'driver',
+          'cache',
+          'readonly',
+          'io',
+        ]
+        fail "#{(value.keys - valid_keys).join(' and ')} is not one of #{valid_keys.join(' or ')}" unless (value.keys - valid_keys).empty?
+      end
+    end
+    munge do |value|
+      if ! value.is_a?(Hash)
+        Puppet.deprecation_warning('disks should be a hash.')
+        {
+          'image' => value
+        }
+      else
+        value
+      end
+    end
   end
 
-  # Template Network config
+  # Network Section
   newproperty(:nics, :array_matching => :all) do
-    desc "Array of nic definitions."
+    desc "An array of hash for Network Section"
+    defaultto []
+    validate do |value|
+      if value.is_a?(Hash)
+        # TODO: validate each key
+        valid_keys = [
+          'network_id',
+          'network',
+          'network_uid',
+          'network_uname',
+          'ip',
+          'mac',
+          'bridge',
+          'target',
+          'script',
+          'model',
+          'white_ports_tcp',
+          'black_ports_tcp',
+          'white_ports_udp',
+          'black_ports_udp',
+          'icmp',
+        ]
+        fail "#{(value.keys - valid_keys).join(' and ')} is not one of #{valid_keys.join(' or ')}" unless (value.keys - valid_keys).empty?
+      end
+    end
+    munge do |value|
+      if ! value.is_a?(Hash)
+        Puppet.deprecation_warning('nics should be a hash.')
+        {
+          'network' => value
+        }
+      else
+        value
+      end
+    end
   end
 
   newproperty(:nic_model) do
-      desc "Model to use for all network interfaces" +
-          "e.g. virtio for kvm"
+    desc "Model to use for all network interfaces" +
+      "e.g. virtio for kvm"
+    validate do |value|
+      Puppet.deprecation_warning('nic_model is deprecated, please use nics hash instead.')
+    end
   end
 
-  # Template Input/Output config
+  # I/O Devices Section
+  newproperty(:graphics) do
+    desc "A hash for I/O Devices Section"
+    defaultto {}
+    validate do |value|
+      # TODO: validate each key
+      valid_keys = [
+        'type',
+        'listen',
+        'port',
+        'passwd',
+        'keymap',
+      ]
+      fail "#{(value.keys - valid_keys).join(' and ')} is not one of #{valid_keys.join(' or ')}" unless (value.keys - valid_keys).empty?
+    end
+  end
+
   newproperty(:graphics_type) do
     desc "Graphics type - vnc or sdl"
 
     defaultto "vnc"
+    validate do |value|
+      Puppet.deprecation_warning('graphics_type is deprecated, please use graphics hash instead.')
+    end
+    munge do |value|
+      resource[:graphics] ||= {}
+      resource[:graphics]['type'] = value
+      nil
+    end
   end
 
   newproperty(:graphics_listen) do
     desc "IP to listen on."
 
     defaultto "0.0.0.0"
+    validate do |value|
+      Puppet.deprecation_warning('graphics_listen is deprecated, please use graphics hash instead.')
+    end
+    munge do |value|
+      resource[:graphics] ||= {}
+      resource[:graphics]['listen'] = value
+      nil
+    end
   end
 
   newproperty(:graphics_port) do
     desc "Port for the VNC server. If left empty this is automatically set."
+    validate do |value|
+      Puppet.deprecation_warning('graphics_port is deprecated, please use graphics hash instead.')
+    end
+    munge do |value|
+      resource[:graphics] ||= {}
+      resource[:graphics]['port'] = value
+      nil
+    end
   end
 
   newproperty(:graphics_passwd) do
     desc "VNC password."
+    validate do |value|
+      Puppet.deprecation_warning('graphics_passwd is deprecated, please use graphics hash instead.')
+    end
+    munge do |value|
+      resource[:graphics] ||= {}
+      resource[:graphics]['passwd'] = value
+      nil
+    end
   end
 
   newproperty(:graphics_keymap) do
     desc "keyboard configuration locale to use in the VNC display"
+    validate do |value|
+      Puppet.deprecation_warning('graphics_keymap is deprecated, please use graphics hash instead.')
+    end
+    munge do |value|
+      resource[:graphics] ||= {}
+      resource[:graphics]['keymap'] = value
+      nil
+    end
   end
 
-  # Template Context config
-  # generic context
+  # Context Section
   newproperty(:context) do
     desc "Pass context hash to vm."
+    defaultto {}
   end
 
   # network & SSH section
   newproperty(:context_ssh) do
-      desc "Activate SSH contextualization"
+    desc "Activate SSH contextualization"
+    munge do |value|
+      resource[:context] ||= {}
+      resource[:context]['ssh'] = value
+      nil
+    end
   end
 
   newproperty(:context_ssh_pubkey) do
-      desc "Root SSH pub key contextualization"
+    desc "Root SSH pub key contextualization"
+    munge do |value|
+      resource[:context] ||= {}
+      resource[:context]['ssh_pubkey'] = value
+      nil
+    end
   end
 
   newproperty(:context_network) do
-      desc "Activate network contextualization"
+    desc "Activate network contextualization"
+    munge do |value|
+      resource[:context] ||= {}
+      resource[:context]['network'] = value
+      nil
+    end
   end
 
   newproperty(:context_onegate) do
-      desc "Activate OneGate token in contextualization"
+    desc "Activate OneGate token in contextualization"
+    munge do |value|
+      resource[:context] ||= {}
+      resource[:context]['onegate'] = value
+      nil
+    end
   end
 
   # Files section
   newproperty(:context_files, :array_matching => :all) do
-      desc "Array of additional contextualization files"
+    desc "Array of additional contextualization files"
+    munge do |value|
+      resource[:context] ||= {}
+      resource[:context]['files'] = value
+      nil
+    end
   end
 
   newproperty(:context_variables) do
-      desc "Hash of additional contextualization variables"
+    desc "Hash of additional contextualization variables"
+    munge do |value|
+      resource[:context] ||= {}
+      resource[:context].merge!(value)
+      nil
+    end
   end
 
   # Template Scheduling config
   # placement section
   newproperty(:context_placement_host) do
-      desc "Host where to place the vm using this template"
+    desc "Host where to place the vm using this template"
+    munge do |value|
+      resource[:context] ||= {}
+      resource[:context]['placement_host'] = value
+      nil
+    end
   end
 
   newproperty(:context_placement_cluster) do
-      desc "Cluster where to place the vm using this template"
+    desc "Cluster where to place the vm using this template"
+    munge do |value|
+      resource[:context] ||= {}
+      resource[:context]['placement_cluster'] = value
+      nil
+    end
   end
 
   # policy section
   newproperty(:context_policy) do
-      desc "Activate policy how to distribute vm using this template"
+    desc "Activate policy how to distribute vm using this template"
+    munge do |value|
+      resource[:context] ||= {}
+      resource[:context]['policy'] = value
+      nil
+    end
   end
 
 end

--- a/spec/acceptance/onetemplate_spec.rb
+++ b/spec/acceptance/onetemplate_spec.rb
@@ -6,12 +6,15 @@ describe 'onetemplate type' do
     class { 'one':
       oned => true,
     }
+    onetemplate { 'test-vm':
+      ensure => absent,
+    }
     EOS
     apply_manifest(pp, :catch_failures => true)
     apply_manifest(pp, :catch_changes => true)
   end
 
-  describe 'when creating a template' do
+  describe 'when creating a template with deprecated properties' do
     it 'should idempotently run' do
       pp = <<-EOS
         onetemplate { 'test-vm':
@@ -39,6 +42,69 @@ describe 'onetemplate type' do
           graphics_type   => 'vnc',
           graphics_listen => '0.0.0.0',
           graphics_port   => 5,
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+  end
+
+  describe 'when destroying a template' do
+    it 'should idempotently run' do
+      pp =<<-EOS
+      onetemplate { 'test-vm':
+        ensure => absent,
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+  end
+
+  describe 'when creating a template' do
+    it 'should idempotently run' do
+      pp = <<-EOS
+        onetemplate { 'test-vm':
+          # Capacity
+          cpu    => 1,
+          memory => 128,
+
+          # OS
+          os     => {
+            kernel     => '/vmlinuz',
+            initrd     => '/initrd.img',
+            root       => 'sda1',
+            kernel_cmd => 'ro xencons=tty console=tty1',
+          },
+
+          # Features
+          features => {
+            acpi        => true,
+            pae         => true,
+          },
+
+          # Disks
+          disks  => [
+            { image => 'Data',},
+            { image => 'Experiments',},
+            { type => 'fs', size => 4096, format => 'ext3',},
+            { type => 'swap', size => 1024, },
+          ],
+
+          # Network
+          nics   => [
+            { network => 'Blue', bridge => 'vbr0', },
+            { network => 'Red', bridge => 'vbr1', },
+          ],
+
+          # I/O Devices
+          graphics => {
+            type   => 'vnc',
+            listen => '0.0.0.0',
+            port   => 5,
+          },
         }
       EOS
 

--- a/spec/acceptance/onevm_spec.rb
+++ b/spec/acceptance/onevm_spec.rb
@@ -12,25 +12,39 @@ describe 'onevm type' do
       memory => 128,
 
       # OS
-      os_kernel     => '/vmlinuz',
-      os_initrd     => '/initrd.img',
-      os_root       => 'sda1',
-      os_kernel_cmd => 'ro xencons=tty console=tty1',
+      os     => {
+        kernel     => '/vmlinuz',
+        initrd     => '/initrd.img',
+        root       => 'sda1',
+        kernel_cmd => 'ro xencons=tty console=tty1',
+      },
 
       # Features
-      acpi        => true,
-      pae         => true,
+      features => {
+        acpi        => true,
+        pae         => true,
+      },
 
       # Disks
-      disks  => [ 'Data', 'Experiments', ],
+      disks  => [
+        { image => 'Data',},
+        { image => 'Experiments',},
+        { type => 'fs', size => 4096, format => 'ext3',},
+        { type => 'swap', size => 1024, },
+      ],
 
       # Network
-      nics   => [ 'Blue', 'Red', ],
+      nics   => [
+        { network => 'Blue', bridge => 'vbr0', },
+        { network => 'Red', bridge => 'vbr1', },
+      ],
 
       # I/O Devices
-      graphics_type   => 'vnc',
-      graphics_listen => '0.0.0.0',
-      graphics_port   => 5,
+      graphics => {
+        type   => 'vnc',
+        listen => '0.0.0.0',
+        port   => 5,
+      },
     }
     EOS
     apply_manifest(pp, :catch_failures => true)


### PR DESCRIPTION
/!\ This PR breaks the API by changing the `onetemplate` type using hashs (in accordance with @tuxmea ) to make it more flexible. Comments welcome.
