### PR TITLE
Use ruby bindings instead of cli in onehost provider

### DIFF
--- a/lib/puppet/provider/one.rb
+++ b/lib/puppet/provider/one.rb
@@ -1,0 +1,35 @@
+##############################################################################
+# Environment Configuration
+##############################################################################
+ONE_LOCATION=ENV["ONE_LOCATION"]
+
+if !ONE_LOCATION
+    RUBY_LIB_LOCATION="/usr/lib/one/ruby"
+else
+    RUBY_LIB_LOCATION=ONE_LOCATION+"/lib/ruby"
+end
+
+$: << RUBY_LIB_LOCATION
+
+##############################################################################
+# Required libraries
+##############################################################################
+require 'opennebula'
+
+class Puppet::Provider::One < Puppet::Provider
+
+  def client
+    @client ||= OpenNebula::Client.new(
+      File.read('/var/lib/one/.one/one_auth'),
+      'http://localhost:2633/RPC2'
+    )
+  end
+
+  def self.client
+    @client ||= OpenNebula::Client.new(
+      File.read('/var/lib/one/.one/one_auth'),
+      'http://localhost:2633/RPC2'
+    )
+  end
+
+end


### PR DESCRIPTION
@tuxmea on second thought, I'm not sure using ruby bindings instead of calling cli is a good idea. Puppet providers's `:commands` helper manages error throwing, and when using ruby bindings we have to manage errors. I still PR this and let you decide if it's a good solution or not.