### PR TITLE
lsbmajdistrelease doesnt exist on rhel7/centos7

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,8 @@
 fixtures:
     repositories:
         stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-        apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
+        apt: 
+          repo: "https://github.com/puppetlabs/puppetlabs-apt.git"
+          ref: "1.8.0"
     symlinks:
         one: "../../../"

--- a/manifests/compute_node/config.pp
+++ b/manifests/compute_node/config.pp
@@ -76,7 +76,7 @@ class one::compute_node::config (
     }
   }
 
-  if $::osfamily == 'RedHat' and versioncmp($::lsbmajdistrelease, '7') < 0  {
+  if $::osfamily == 'RedHat' and versioncmp($::operatingsystemmajrelease, '7') < 0  {
     file { '/sbin/brctl':
       ensure => link,
       target => '/usr/sbin/brctl',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -153,7 +153,7 @@ class one::params (
   # OS specific params for nodes
   case $::osfamily {
     'RedHat': {
-      if $::lsbmajdistrelease == '7' {
+      if $::operatingsystemmajrelease== '7' {
         $node_packages = ['opennebula-node-kvm',
                           'sudo'
                           ]

--- a/manifests/prerequisites.pp
+++ b/manifests/prerequisites.pp
@@ -45,17 +45,18 @@ class one::prerequisites {
           default: { fail("Unrecognized operating system ${::operatingsystem}") }
         }
 
+        apt::key { 'one_repo_key':
+          key        => '85E16EBF',
+          key_source => 'http://downloads.opennebula.org/repo/Debian/repo.key',
+        } ->
+
         apt::source { 'one-official':
           location          => "http://downloads.opennebula.org/repo/${apt_location}",
           release           => 'stable',
           repos             => 'opennebula',
+          required_packages => 'debian-keyring debian-archive-keyring',
           pin               => $apt_pin,
-          require           => Apt::Key['one_repo_key'],
-        }
-
-        apt::key { 'one_repo_key':
-          id        => '85E16EBF',
-          source    => 'http://downloads.opennebula.org/repo/Debian/repo.key',
+          include_src       => false,
         }
       }
     }

--- a/manifests/prerequisites.pp
+++ b/manifests/prerequisites.pp
@@ -19,62 +19,60 @@
 # http://www.apache.org/licenses/LICENSE-2.0.html
 #
 class one::prerequisites {
-    case $::osfamily {
-        'RedHat': {
-            if ( $one::one_repo_enable == 'true' ) {
-                yumrepo { 'opennebula':
-                    baseurl  => "http://downloads.opennebula.org/repo/4.10/CentOS/${::operatingsystemmajrelease}/x86_64/",
-                    descr    => 'OpenNebula',
-                    enabled  => 1,
-                    gpgcheck => 0,
-                }
-            }
+  case $::osfamily {
+    'RedHat': {
+      if ( $one::one_repo_enable == 'true' ) {
+        yumrepo { 'opennebula':
+          baseurl  => "http://downloads.opennebula.org/repo/4.10/CentOS/${::operatingsystemmajrelease}/x86_64/",
+          descr    => 'OpenNebula',
+          enabled  => 1,
+          gpgcheck => 0,
         }
-        'Debian' : {
-            if ($one::one_repo_enable == 'true') {
-                include ::apt
-                case $::operatingsystem {
-                  'Debian': {
-                    $apt_location="4.10/Debian/${::lsbmajdistrelease}"
-                    $apt_pin='-10'
-                  }
-                  'Ubuntu': {
-                    $apt_location="4.10/Ubuntu/${::lsbdistrelease}"
-                    $apt_pin='500'
-                  }
-                  default: { fail("Unrecognized operating system ${::operatingsystem}") }
-                }
+      }
+    }
+    'Debian' : {
+      if ($one::one_repo_enable == 'true') {
+        include ::apt
+        case $::operatingsystem {
+          'Debian': {
+            $apt_location="4.10/Debian/${::operatingsystemmajrelease}"
+            $apt_pin='-10'
+          }
+          'Ubuntu': {
+            $apt_location="4.10/Ubuntu/${::operatingsystemmajrelease}"
+            $apt_pin='500'
+          }
+          default: { fail("Unrecognized operating system ${::operatingsystem}") }
+        }
 
-                apt::source { 'one-official':
-                  location          => "http://downloads.opennebula.org/repo/${apt_location}",
-                  release           => 'stable',
-                  repos             => 'opennebula',
-                  required_packages => 'debian-keyring debian-archive-keyring',
-                  pin               => $apt_pin,
-                  include_src       => false,
-                  require           => Apt::Key['one_repo_key'],
-                }
+        apt::source { 'one-official':
+          location          => "http://downloads.opennebula.org/repo/${apt_location}",
+          release           => 'stable',
+          repos             => 'opennebula',
+          pin               => $apt_pin,
+          require           => Apt::Key['one_repo_key'],
+        }
 
-                apt::key { 'one_repo_key':
-                  key        => '85E16EBF',
-                  key_source => 'http://downloads.opennebula.org/repo/Debian/repo.key',
-                }
-            }
+        apt::key { 'one_repo_key':
+          id        => '85E16EBF',
+          source    => 'http://downloads.opennebula.org/repo/Debian/repo.key',
         }
-        default: {
-            notice('We use opennebula from default OS repositories.')
-        }
+      }
     }
-    group { 'oneadmin':
-        ensure => present,
-        gid    => $one::onegid,
+    default: {
+      notice('We use opennebula from default OS repositories.')
     }
-    user { 'oneadmin':
-        ensure     => present,
-        uid        => $one::oneuid,
-        gid        => $one::onegid,
-        home       => '/var/lib/one',
-        managehome => true,
-        shell      => '/bin/bash'
-    }
+  }
+  group { 'oneadmin':
+    ensure => present,
+    gid    => $one::onegid,
+  }
+  user { 'oneadmin':
+    ensure     => present,
+    uid        => $one::oneuid,
+    gid        => $one::onegid,
+    home       => '/var/lib/one',
+    managehome => true,
+    shell      => '/bin/bash'
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -24,6 +24,6 @@
    ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": "> 2.2.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 1.7.0" }
+    { "name": "puppetlabs/apt", "version_requirement": "< 2.0.0" }
   ]
 }

--- a/spec/classes/opennebula_rhel_spec.rb
+++ b/spec/classes/opennebula_rhel_spec.rb
@@ -14,7 +14,7 @@ describe 'one' do
   end
   let(:hiera_config) { hiera_config }
   context 'with hiera config on RedHat 6' do
-    let (:facts) { {:osfamily => 'RedHat', :lsbmajdistrelease => '6', } }
+    let (:facts) { {:osfamily => 'RedHat', :operatingsystemmajrelease => '6', } }
     let(:params) { {:oned => true} }
     hiera = Hiera.new(:config => hiera_config)
     configdir = '/etc/one'
@@ -258,7 +258,7 @@ describe 'one' do
   end
 
   context 'with hiera config on RedHat 7' do
-    let (:facts) { {:osfamily => 'RedHat', :lsbmajdistrelease => '7', } }
+    let (:facts) { {:osfamily => 'RedHat', :operatingsystemmajrelease => '7', } }
     let(:params) { {:oned => true} }
     hiera = Hiera.new(:config => hiera_config)
     configdir = '/etc/one'


### PR DESCRIPTION
lsbmajdistrelease is only valid if redhat-lsb or the equivalent is installed. this will pull 170+ packages on a blank installation. therefore we should move to operatingsystemmajrelease.