### PR TITLE
Fix sunstone

### DIFF
--- a/manifests/oned/sunstone/config.pp
+++ b/manifests/oned/sunstone/config.pp
@@ -24,11 +24,11 @@ class one::oned::sunstone::config (
 ){
   File {
     owner   => 'root',
+    group   => 'oneadmin',
   }
   file { '/usr/lib/one/sunstone':
     ensure  => directory,
     owner   => 'oneadmin',
-    group   => 'oneadmin',
     mode    => '0755',
     recurse => true,
   } ->

--- a/spec/classes/one__oned__sunstone__config_spec.rb
+++ b/spec/classes/one__oned__sunstone__config_spec.rb
@@ -17,6 +17,7 @@ describe 'one::oned::sunstone::config', :type => :class do
         }
         it { should contain_file('/etc/one/sunstone-views/admin.yaml') \
         .with_ensure('file') \
+        .with_group('oneadmin') \
         .with_mode('0640')
         }
       end
@@ -28,6 +29,7 @@ describe 'one::oned::sunstone::config', :type => :class do
       end
       context 'with sunstone listen not ip set' do
         it { should contain_file('/etc/one/sunstone-server.conf') \
+        .with_group('oneadmin') \
         .with_content(/:host: /m)
         }
       end
@@ -39,7 +41,9 @@ describe 'one::oned::sunstone::config', :type => :class do
     - vcenter
     - support'
 
-        it { should contain_file('/etc/one/sunstone-server.conf').with_content(/#{expected_routes}/m)
+        it { should contain_file('/etc/one/sunstone-server.conf') \
+        .with_group('oneadmin') \
+        .with_content(/#{expected_routes}/m)
         }
       end
       context 'with support disabled' do
@@ -54,12 +58,14 @@ describe 'one::oned::sunstone::config', :type => :class do
       context 'with marketplace enabled' do
         let (:params) { {:enable_marketplace => 'yes'} }
         it { should contain_file('/etc/one/sunstone-views.yaml') \
+        .with_group('oneadmin') \
         .with_content(/- marketplace-tab/m)
         }
       end
       context 'with marketplace disabled' do
         let (:params) { {:enable_marketplace => 'no'} }
         it { should_not contain_file('/etc/one/sunstone-views.yaml') \
+        .with_group('oneadmin') \
         .with_content(/- marketplace-tab/m)
         }
       end


### PR DESCRIPTION
If one sets 0640 on the sunstone config and it is not part of the group or the owner, it can't read its config, which is bad. So lets add the group oneadmin again, because thats the group which sunstone will use.