### PR TITLE
added support toggle to sunstone views template

### DIFF
--- a/templates/sunstone-views.yaml.erb
+++ b/templates/sunstone-views.yaml.erb
@@ -24,7 +24,9 @@ available_tabs:
     - oneflow-services
     - oneflow-templates
     - provision-tab
+<% if @enable_support == 'yes' -%>
     - support-tab
+<% end -%>
 groups:
     oneadmin:
         - admin


### PR DESCRIPTION
With this patch the support tab is hidden if the Hiera flag one::oned::enable_support is set to 'no'.