### PR TITLE
Add parameter for sunstone sessions

### DIFF
--- a/manifests/oned/sunstone/config.pp
+++ b/manifests/oned/sunstone/config.pp
@@ -21,6 +21,7 @@ class one::oned::sunstone::config (
   $enable_support     = $one::enable_support,
   $enable_marketplace = $one::enable_marketplace,
   $tmpdir             = $one::sunstone_tmpdir,
+  $sessions           = $one::sunstone_sessions,
 ){
   File {
     owner   => 'root',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -63,6 +63,7 @@ class one::params {
   $enable_support            = hiera('one::oned::enable_support', 'yes')
   $enable_marketplace        = hiera('one::oned::enable_marketplace', 'yes')
   $sunstone_tmpdir           = hiera('one::oned::sunstone_tmpdir', '/var/tmp')
+  $sunstone_sessions         = hiera('one::oned::sunstone_sessions', 'memory')
 
   # generic params for nodes and oned
   $oneuid = '9869'

--- a/templates/sunstone-server.conf.erb
+++ b/templates/sunstone-server.conf.erb
@@ -37,7 +37,7 @@
 #
 # NOTE. memcache needs a separate memcached server to be configured. Refer
 # to memcached documentation to configure the server.
-:sessions: memory
+:sessions: <%= @sessions %>
 
 # Memcache configuration
 :memcache_host: localhost


### PR DESCRIPTION
Added a parameter for sunstone sessions - default is memory but under
passenger needs to be set to memcache.