### PR TITLE
inherit FILTER_{IP,MAC}_SPOOFING by default

### DIFF
--- a/templates/oned.conf.erb
+++ b/templates/oned.conf.erb
@@ -871,6 +871,8 @@ INHERIT_DATASTORE_ATTR  = "GLUSTER_VOLUME"
 
 INHERIT_VNET_ATTR       = "VLAN_TAGGED_ID"
 INHERIT_VNET_ATTR       = "BRIDGE_OVS"
+INHERIT_VNET_ATTR       = "FILTER_IP_SPOOFING"
+INHERIT_VNET_ATTR       = "FILTER_MAC_SPOOFING"
 
 #*******************************************************************************
 # Transfer Manager Driver Behavior Configuration


### PR DESCRIPTION
These are now inherited by default in 4.12 release