### PR TITLE
add support for setting INHERIT_DATASTORE_ATTRs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -361,6 +361,7 @@ class one (
             $hook_scripts_path              = $one::params::hook_scripts_path,
             $hook_scripts_pkgs              = $one::params::hook_scripts_pkgs,
             $hook_scripts                   = $one::params::hook_scripts,
+            $inherit_datastore_attrs        = $one::params::inherit_datastore_attrs,
             $oned_onegate_ip                = $one::params::oned_onegate_ip,
             $kickstart_network              = $one::params::kickstart_network,
             $kickstart_partition            = $one::params::kickstart_partition,

--- a/manifests/oned/config.pp
+++ b/manifests/oned/config.pp
@@ -21,6 +21,7 @@ class one::oned::config(
   $hook_scripts            = $one::hook_scripts,
   $vm_hook_scripts         = $one::vm_hook_scripts,
   $host_hook_scripts       = $one::host_hook_scripts,
+  $inherit_datastore_attrs = $one::inherit_datastore_attrs,
   $oned_port               = $one::oned_port,
   $oned_db                 = $one::oned_db,
   $oned_db_user            = $one::oned_db_user,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -66,6 +66,11 @@ class one::params {
   $xmlrpc_keepalive_max_conn = hiera('one::oned::xmlrpc_keepalive_max_conn', '30')
   $xmlrpc_timeout            = hiera('one::oned::xmlrpc_timeout', '15')
 
+  # OpenNebula INHERIT attrs
+  # (NOTE: setting default to undef causes value to show up as "" in ERB
+  # template for ruby 1.9.x)
+  $inherit_datastore_attrs   = hiera('one::oned::inherit_datastore_attrs', [])
+
   # Sunstone configuration parameters
   $sunstone_listen_ip        = hiera('one::oned::sunstone_listen_ip', '127.0.0.1')
   $enable_support            = hiera('one::oned::enable_support', 'yes')
@@ -152,6 +157,11 @@ class one::params {
 
   # ensure xmlrpctuning is in string
   validate_string($xmlrpc_maxconn, $xmlrpc_maxconn_backlog, $xmlrpc_keepalive_timeout, $xmlrpc_keepalive_max_conn, $xmlrpc_timeout)
+
+  # ensure INHERIT attrs is array
+  if ($inherit_datastore_attrs) {
+    validate_array($inherit_datastore_attrs)
+  }
 
   if ($hook_scripts_pkgs) {
     validate_array($hook_scripts_pkgs)

--- a/templates/oned.conf.erb
+++ b/templates/oned.conf.erb
@@ -869,6 +869,12 @@ INHERIT_DATASTORE_ATTR  = "CEPH_USER"
 INHERIT_DATASTORE_ATTR  = "GLUSTER_HOST"
 INHERIT_DATASTORE_ATTR  = "GLUSTER_VOLUME"
 
+<%- if @inherit_datastore_attrs != nil -%>
+  <%- @inherit_datastore_attrs.each do |attr| -%>
+INHERIT_DATASTORE_ATTR  = "<%= attr %>"
+  <%- end -%>
+<%- end -%>
+
 INHERIT_VNET_ATTR       = "VLAN_TAGGED_ID"
 INHERIT_VNET_ATTR       = "BRIDGE_OVS"
 


### PR DESCRIPTION
This adds support for setting INHERIT_DATASTORE_ATTR settings in oned.conf, e.g.:
```
one::oned::inherit_datastore_attrs:
  - 'DRIVER'
```