### PR TITLE
fix to allow updating a onevnet_addressrange

### DIFF
--- a/lib/puppet/provider/onevnet_addressrange/cli.rb
+++ b/lib/puppet/provider/onevnet_addressrange/cli.rb
@@ -98,6 +98,8 @@ Puppet::Type.type(:onevnet_addressrange).provide(:cli) do
         case k
           when :ip_size
             [ 'SIZE', v ]
+          when :ip_start
+            [ 'IP', v ]
           when :globalprefix
             [ 'GLOBAL_PREFIX', v ]
           when :ulaprefix
@@ -112,7 +114,7 @@ Puppet::Type.type(:onevnet_addressrange).provide(:cli) do
     file.close
     self.debug(IO.read file.path)
     self.debug(@property_hash)
-    onevnet('updatear', resource[:onevnet_name], ar_id, file.path ) unless ( @property_hash.empty? or ar_id.nil? or defined? ar_id )
+    onevnet('updatear', resource[:onevnet_name], ar_id, file.path ) unless ( @property_hash.empty? or ar_id.nil? or !defined? ar_id )
     file.delete
   end
 


### PR DESCRIPTION
This fixes a parameter name mismatch and a bug preventing the updatear
command from being run.