### PR TITLE
enable :encode_user_password when using ldap auth

### DIFF
--- a/templates/sunstone-server.conf.erb
+++ b/templates/sunstone-server.conf.erb
@@ -71,6 +71,14 @@
 #
 :core_auth: cipher
 
+# For LDAP auth. Encode credentials sent to OpenNebula. Turns espaces into %20.
+# This only works with "opennebula" auth.
+#
+# :encode_user_password: true
+<% if scope.lookupvar('one::ldap') -%>
+:encode_user_password: true
+<% end -%>
+
 ################################################################################
 # UI Settings
 ################################################################################


### PR DESCRIPTION
This :encode_user_password setting was added to the sunstone-server.conf in 4.12 release. It's only for LDAP auth so this PR just sets it to true if `one::ldap` is set to `true`.