### PR TITLE
add support for configuring KVM driver

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -402,6 +402,8 @@ class one (
             $libvirtd_srv                   = $one::params::libvirtd_srv,
             $libvirtd_cfg                   = $one::params::libvirtd_cfg,
             $libvirtd_source                = $one::params::libvirtd_source,
+            $kvm_driver_emulator            = $one::params::kvm_driver_emulator,
+            $kvm_driver_nic_attrs           = $one::params::kvm_driver_nic_attrs,
             $rubygems                       = $one::params::rubygems,
             $sched_interval                 = $one::params::sched_interval,
             $sched_max_vm                   = $one::params::sched_max_vm,

--- a/manifests/oned/config.pp
+++ b/manifests/oned/config.pp
@@ -50,6 +50,8 @@ class one::oned::config(
   $sched_default_ds_rank   = $one::sched_default_ds_rank,
   $sched_log_system        = $one::sched_log_system,
   $sched_log_debug_level   = $one::sched_log_debug_level,
+  $kvm_driver_emulator     = $one::kvm_driver_emulator,
+  $kvm_driver_nic_attrs    = $one::kvm_driver_nic_attrs,
   ) {
 
   if ! member(['YES', 'NO'], $oned_vm_submit_on_hold) {
@@ -119,6 +121,13 @@ class one::oned::config(
     purge   => true,
     force   => true,
     source  => $hook_scripts_path,
+  }
+
+  file { '/etc/one/vmm_exec/vmm_exec_kvm.conf':
+    ensure  => file,
+    owner   => 'root',
+    mode    => '0640',
+    content => template('one/vmm_exec_kvm.conf.erb'),
   }
 
   if ($backend == 'mysql') {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,6 +71,10 @@ class one::params {
   # template for ruby 1.9.x)
   $inherit_datastore_attrs   = hiera('one::oned::inherit_datastore_attrs', [])
 
+  # OpenNebula KVM driver parameters
+  $kvm_driver_emulator       = hiera ('one::oned::kvm_driver_emulator', 'undef')
+  $kvm_driver_nic_attrs      = hiera ('one::oned::kvm_driver_nic_attrs', 'undef')
+
   # Sunstone configuration parameters
   $sunstone_listen_ip        = hiera('one::oned::sunstone_listen_ip', '127.0.0.1')
   $enable_support            = hiera('one::oned::enable_support', 'yes')

--- a/templates/vmm_exec_kvm.conf.erb
+++ b/templates/vmm_exec_kvm.conf.erb
@@ -1,0 +1,61 @@
+# -------------------------------------------------------------------------- #
+# Copyright 2002-2015, OpenNebula Project (OpenNebula.org), C12G Labs        #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may    #
+# not use this file except in compliance with the License. You may obtain    #
+# a copy of the License at                                                   #
+#                                                                            #
+# http://www.apache.org/licenses/LICENSE-2.0                                 #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+#--------------------------------------------------------------------------- #
+
+# Default configuration attributes for the KVM driver
+# (all domains will use these values as defaults).  These values can
+# be overridden in each VM template. Valid atributes are:
+#  - emulator
+#  - os [kernel,initrd,boot,root,kernel_cmd,arch,machine]
+#  - vcpu
+#  - features [acpi, pae, apic, hyperv, localtime]
+#  - disk [driver, cache, io, total_bytes_sec, total_iops_sec, read_bytes_sec, write_bytes_sec, read_iops_sec, write_iops_sec]
+#  - nic  [filter, model]
+#  - raw
+#  - hyperv_options: options used for FEATURES = [ HYPERV = yes ]
+# NOTE: raw attribute value is appended to that on the VM template
+
+#EMULATOR = /usr/libexec/qemu-kvm
+<% if scope.lookupvar('one::kvm_driver_emulator') != 'undef' -%>
+EMULATOR = <%= scope.lookupvar('one::kvm_driver_emulator') %>
+<% end -%>
+
+#VCPU = 1
+
+OS       = [ boot = "hd", arch = "x86_64" ]
+FEATURES = [ PAE = "no", ACPI = "yes", APIC = "no", HYPERV = "no" ]
+
+DISK     = [ driver = "raw" , cache = "none"]
+
+#NIC     = [ filter = "clean-traffic", model="virtio" ]
+<% if scope.lookupvar('one::kvm_driver_nic_attrs') != 'undef' -%>
+NIC = <%= scope.lookupvar('one::kvm_driver_nic_attrs') %>
+<% end -%>
+#RAW     = "<devices><serial type=\"pty\"><source path=\"/dev/pts/5\"/><target port=\"0\"/></serial><console type=\"pty\" tty=\"/dev/pts/5\"><source path=\"/dev/pts/5\"/><target port=\"0\"/></console></devices>"
+
+HYPERV_OPTIONS="<relaxed state='on'/><vapic state='on'/><spinlocks state='on' retries='4096'/>"
+
+SPICE_OPTIONS="
+    <video>
+        <model type='qxl' heads='1'/>
+    </video>
+         <sound model='ich6' />
+    <channel type='spicevmc'>
+        <target type='virtio' name='com.redhat.spice.0'/>
+    </channel>
+    <redirdev bus='usb' type='spicevmc'/>
+    <redirdev bus='usb' type='spicevmc'/>
+    <redirdev bus='usb' type='spicevmc'/>"
+


### PR DESCRIPTION
This adds support for configuring the emulator and NIC attributes settings in the KVM driver:

```
one::oned::kvm_driver_emulator: '/usr/libexec/qemu-kvm'
one::oned::kvm_driver_nic_attrs: '[ filter="clean-traffic", model="virtio" ]'
```