### PR TITLE
add missing ceph params

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,17 @@ This means: addressranges which are not set by Puppet will not be visible using 
 Create a ONE Datastore
 ```
 onedatastore { '<name>':
-    ensure   => present | absent,
-    type     => 'IMAGE_DS' | 'SYSTEM_DS' | 'FILE_DS',
-    dm       => 'fs' | 'vmware' | 'iscsi' | 'lvm' | 'vmfs' | 'ceph',
-    tm       => 'shared' | 'ssh' | 'qcow2' | 'iscsi' | 'lvm' | 'vmfs' | 'ceph' | 'dummy',
-    disktype => 'file' | 'block' | 'rdb',
-    basepath => '/var/lib/one/datastore',
+    ensure     => present | absent,
+    type       => 'IMAGE_DS' | 'SYSTEM_DS' | 'FILE_DS',
+    dm         => 'fs' | 'vmware' | 'iscsi' | 'lvm' | 'vmfs' | 'ceph',
+    tm         => 'shared' | 'ssh' | 'qcow2' | 'iscsi' | 'lvm' | 'vmfs' | 'ceph' | 'dummy',
+    cephhost   => 'cephhost', # (optional: ceph only)
+    cephuser   => 'cephuser', # (optional: ceph only)
+    cephsecret => 'ceph-secret-here', # (optional: ceph only)
+    poolname   => 'cephpoolname', # (optional: ceph only)
+    bridgelist => 'host1 host2 host3', # (optional: ceph only)
+    disktype   => 'file' | 'block' | 'rdb',
+    basepath   => '/var/lib/one/datastore',
 }
 ```
 

--- a/lib/puppet/provider/onedatastore/cli.rb
+++ b/lib/puppet/provider/onedatastore/cli.rb
@@ -36,6 +36,9 @@ Puppet::Type.type(:onedatastore).provide(:cli) do
             xml.DS_MAD resource[:dm]
             xml.BRIDGE_LIST resource[:bridgelist]
             xml.CEPH_HOST resource[:cephhost]
+            xml.CEPH_USER resource[:cephuser]
+            xml.CEPH_SECRET resource[:cephsecret]
+            xml.POOL_NAME resource[:poolname]
             xml.STAGING_DIR resource[:stagingdir]
             xml.BASE_PATH do
                 resource[:basepath]
@@ -72,6 +75,9 @@ Puppet::Type.type(:onedatastore).provide(:cli) do
             :basepath   => (datastore.xpath('./TEMPLATE/BASE_PATH').text unless datastore.xpath('./TEMPLATE/BASE_PATH').nil?),
             :bridgelist => (datastore.xpath('./TEMPLATE/BRIDGE_LIST').text unless datastore.xpath('./TEMPLATE/BRIDGE_LIST').nil?),
             :cephhost   => (datastore.xpath('./TEMPLATE/CEPH_HOST').text unless datastore.xpath('./TEMPLATE/CEPH_HOST').nil?),
+            :cephuser   => (datastore.xpath('./TEMPLATE/CEPH_USER').text unless datastore.xpath('./TEMPLATE/CEPH_USER').nil?),
+            :cephsecret => (datastore.xpath('./TEMPLATE/CEPH_SECRET').text unless datastore.xpath('./TEMPLATE/CEPH_SECRET').nil?),
+            :poolname   => (datastore.xpath('./TEMPLATE/POOL_NAME').text unless datastore.xpath('./TEMPLATE/POOL_NAME').nil?),
             :stagingdir => (datastore.xpath('./TEMPLATE/STAGING_DIR').text unless datastore.xpath('./TEMPLATE/STAGING_DIR').nil?),
             :disktype   => {'0' => 'file', '1' => 'block', '3' => 'rbd'}[datastore.xpath('./DISK_TYPE').text]
         )

--- a/lib/puppet/provider/onedatastore/cli.rb
+++ b/lib/puppet/provider/onedatastore/cli.rb
@@ -34,6 +34,7 @@ Puppet::Type.type(:onedatastore).provide(:cli) do
                 xml.send(resource[:safe_dirs].join(' '))
             end if resource[:safe_dirs]
             xml.DS_MAD resource[:dm]
+            xml.DISK_TYPE resource[:disktype]
             xml.BRIDGE_LIST resource[:bridgelist]
             xml.CEPH_HOST resource[:cephhost]
             xml.CEPH_USER resource[:cephuser]

--- a/lib/puppet/type/onedatastore.rb
+++ b/lib/puppet/type/onedatastore.rb
@@ -64,6 +64,19 @@ Puppet::Type.newtype(:onedatastore) do
     desc "List of Ceph monitors, space separated"
   end
 
+  newproperty(:cephuser) do
+    desc "The OpenNebula Ceph user name. If set it is used by RBD commands"
+  end
+
+  newproperty(:cephsecret) do
+    desc "A generated UUID for a LibVirt secret (to hold the CephX authentication " +
+         "key in Libvirt on each hypervisor)"
+  end
+
+  newproperty(:poolname) do
+    desc "The OpenNebula Ceph pool name (defaults to one)"
+  end
+
   newproperty(:stagingdir) do
     desc "Temporary scratch space. Must be big enough to store raw image size plus sparse version"
   end

--- a/spec/acceptance/onedatastore_spec.rb
+++ b/spec/acceptance/onedatastore_spec.rb
@@ -88,8 +88,14 @@ describe 'onedatastore type' do
     it 'should idempotently run' do
       pp = <<-EOS
       onedatastore { 'ceph_ds':
-        dm => 'ceph',
-        tm => 'ceph',
+        dm         => 'ceph',
+        tm         => 'ceph',
+        cephhost   => 'cephhost',
+        cephuser   => 'cephuser',
+        cephsecret => 'cephsecret',
+        pool_name  => 'cephpoolname',
+        disktype   => 'rbd',
+        bridgelist => 'host1 host2 host3'
       }
       EOS
 

--- a/spec/type/onedatastore_spec.rb
+++ b/spec/type/onedatastore_spec.rb
@@ -26,7 +26,8 @@ describe res_type do
     res_type.key_attributes.should == [:name]
   end
 
-  properties = [:type, :dm, :tm, :disktype ]
+  properties = [:type, :dm, :tm, :disktype, :cephhost, :cephuser, :cephsecret,
+                :poolname, :bridgelist]
   properties.each do |property|
     it "should have a #{property} property" do
       described_class.attrclass(property).ancestors.should be_include(Puppet::Property)
@@ -55,6 +56,31 @@ describe res_type do
   it 'should have property :disktype' do
       @datastore[:disktype] = 'file'
       @datastore[:disktype].should == 'file'
+  end
+
+  it 'should have property :cephhost' do
+      @datastore[:cephhost] = 'cephhost'
+      @datastore[:cephhost].should == 'cephhost'
+  end
+
+  it 'should have property :cephuser' do
+      @datastore[:cephuser] = 'cephuser'
+      @datastore[:cephuser].should == 'cephuser'
+  end
+
+  it 'should have property :cephsecret' do
+      @datastore[:cephsecret] = 'cephsecret'
+      @datastore[:cephsecret].should == 'cephsecret'
+  end
+
+  it 'should have property :poolname' do
+      @datastore[:poolname] = 'poolname'
+      @datastore[:poolname].should == 'poolname'
+  end
+
+  it 'should have property :bridgelist' do
+      @datastore[:bridgelist] = 'host1 host2 host3'
+      @datastore[:bridgelist].should == 'host1 host2 host3'
   end
 
   parameter_tests = {


### PR DESCRIPTION
This adds support for the following Ceph datastore parameters: `CEPH_USER`, `CEPH_SECRET`, and `POOL_NAME`. It also adds the missing `DISK_TYPE` element when creating any datastore which prevents a false-positive of trying to modify the `DM`/`DS_MAD` value on future puppet runs.