### PR TITLE
change onevm provider to use template name not id

### DIFF
--- a/lib/puppet/provider/onevm/cli.rb
+++ b/lib/puppet/provider/onevm/cli.rb
@@ -49,10 +49,12 @@ Puppet::Type.type(:onevm).provide(:cli) do
   def self.instances
     vms = Nokogiri::XML(onevm('list','-x')).root.xpath('/VM_POOL/VM')
     vms.collect do |vm|
+        template_id = vm.xpath('./TEMPLATE/TEMPLATE_ID').text
+        template_name = Nokogiri::XML(onetemplate('show',template_id,'-x')).root.xpath('/VMTEMPLATE/NAME').text
         new(
             :name        => vm.xpath('./NAME').text,
             :ensure      => :present,
-            :template    => vm.xpath('./TEMPLATE/TEMPLATE_ID').text,
+            :template    => template_name,
             :description => vm.xpath('./TEMPLATE/DESCRIPTION').text
         )
     end


### PR DESCRIPTION
This fixes an idempotency issue where a onevm defined like this:

```  
  onevm { 'testvm':
    template => 'ttylinux - kvm',
  }
```

will error on subsequent puppet runs, as the provider reads back the template ID not the name.  Error message from subsequent puppet runs:

```
Error: /Stage[main]/Profiles::Opennebula::Controller/Onevm[testvm]/template: change from 0 to ttylinux - kvm failed: Can not modify a VM template
```

This commit changes the onevm provider to look up the name of the template after reading back the template ID.  This means that subsequent puppet runs will run cleanly.

/CC @tuxmea let me know what you think