### PR TITLE
add DRIVER property to onedatastore provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ onedatastore { '<name>':
     type       => 'IMAGE_DS' | 'SYSTEM_DS' | 'FILE_DS',
     dm         => 'fs' | 'vmware' | 'iscsi' | 'lvm' | 'vmfs' | 'ceph',
     tm         => 'shared' | 'ssh' | 'qcow2' | 'iscsi' | 'lvm' | 'vmfs' | 'ceph' | 'dummy',
+    driver     => 'raw | qcow2',
     cephhost   => 'cephhost', # (optional: ceph only)
     cephuser   => 'cephuser', # (optional: ceph only)
     cephsecret => 'ceph-secret-here', # (optional: ceph only)

--- a/lib/puppet/provider/onedatastore/cli.rb
+++ b/lib/puppet/provider/onedatastore/cli.rb
@@ -35,6 +35,7 @@ Puppet::Type.type(:onedatastore).provide(:cli) do
             end if resource[:safe_dirs]
             xml.DS_MAD resource[:dm]
             xml.DISK_TYPE resource[:disktype]
+            xml.DRIVER resource[:driver]
             xml.BRIDGE_LIST resource[:bridgelist]
             xml.CEPH_HOST resource[:cephhost]
             xml.CEPH_USER resource[:cephuser]
@@ -80,6 +81,7 @@ Puppet::Type.type(:onedatastore).provide(:cli) do
             :cephsecret => (datastore.xpath('./TEMPLATE/CEPH_SECRET').text unless datastore.xpath('./TEMPLATE/CEPH_SECRET').nil?),
             :poolname   => (datastore.xpath('./TEMPLATE/POOL_NAME').text unless datastore.xpath('./TEMPLATE/POOL_NAME').nil?),
             :stagingdir => (datastore.xpath('./TEMPLATE/STAGING_DIR').text unless datastore.xpath('./TEMPLATE/STAGING_DIR').nil?),
+            :driver     => (datastore.xpath('./TEMPLATE/DRIVER').text unless datastore.xpath('./TEMPLATE/DRIVER').nil?),
             :disktype   => {'0' => 'file', '1' => 'block', '3' => 'rbd'}[datastore.xpath('./DISK_TYPE').text]
         )
       end

--- a/lib/puppet/type/onedatastore.rb
+++ b/lib/puppet/type/onedatastore.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:onedatastore) do
     desc "Choose a disk type: file, block, rdb"
   end
 
+  newproperty(:driver) do
+    desc "Choose a driver: raw, qcow2"
+  end
+
   newproperty(:basepath) do
     desc "Choose a base path"
   end

--- a/spec/acceptance/onedatastore_spec.rb
+++ b/spec/acceptance/onedatastore_spec.rb
@@ -90,6 +90,7 @@ describe 'onedatastore type' do
       onedatastore { 'ceph_ds':
         dm         => 'ceph',
         tm         => 'ceph',
+        driver     => 'raw',
         cephhost   => 'cephhost',
         cephuser   => 'cephuser',
         cephsecret => 'cephsecret',

--- a/spec/type/onedatastore_spec.rb
+++ b/spec/type/onedatastore_spec.rb
@@ -26,8 +26,8 @@ describe res_type do
     res_type.key_attributes.should == [:name]
   end
 
-  properties = [:type, :dm, :tm, :disktype, :cephhost, :cephuser, :cephsecret,
-                :poolname, :bridgelist]
+  properties = [:type, :dm, :tm, :disktype, :driver, :cephhost, :cephuser,
+                :cephsecret, :poolname, :bridgelist]
   properties.each do |property|
     it "should have a #{property} property" do
       described_class.attrclass(property).ancestors.should be_include(Puppet::Property)
@@ -56,6 +56,11 @@ describe res_type do
   it 'should have property :disktype' do
       @datastore[:disktype] = 'file'
       @datastore[:disktype].should == 'file'
+  end
+
+  it 'should have property :driver' do
+      @datastore[:driver] = 'qcow2'
+      @datastore[:driver].should == 'qcow2'
   end
 
   it 'should have property :cephhost' do


### PR DESCRIPTION
Adds support for specifying `DRIVER` attribute when creating a onedatastore. For ceph datastores this value should be set to `raw`.

/cc @tuxmea 