### PR TITLE
quote variable values in onedatastore flush template

### DIFF
--- a/lib/puppet/provider/onedatastore/cli.rb
+++ b/lib/puppet/provider/onedatastore/cli.rb
@@ -105,7 +105,7 @@ Puppet::Type.type(:onedatastore).provide(:cli) do
       unless resource[k].nil? or resource[k].to_s.empty? or [:name, :provider, :ensure].include?(k)
         [k.to_s.upcase, v]
       end
-    }.map { |a| "#{a[0]} = #{a[1]}" unless a.nil? }.join("\n")
+    }.map { |a| "#{a[0]} = \"#{a[1]}\"" unless a.nil? }.join("\n")
 
     file.write(tempfile)
     file.close


### PR DESCRIPTION
...otherwise you get a syntax error from 'onedatastore update' when values contain spaces (e.g. bridge_list):

```
==> centos: Error: /Stage[main]/Main/Onedatastore[cephds]: Could not evaluate: Execution of '/usr/bin/onedatastore update cephds /tmp/onedatastore-cephds.template --append' returned 255: [DatastoreUpdateTemplate] Cannot update template. Parse error: syntax error, unexpected VARIABLE, expecting EQUAL or EQUAL_EMPTY at line 6, columns 108:117
```

The error above was from:
```
one_datastores:
  cephds:
    ...
    bridge_list: 'host1 host2 host3'
```