### PR TITLE
One datastore remove rescue block + add cluster_id warning

### DIFF
--- a/lib/puppet/provider/onedatastore/cli.rb
+++ b/lib/puppet/provider/onedatastore/cli.rb
@@ -42,6 +42,10 @@ Puppet::Type.type(:onedatastore).provide(:cli) do
       xml.DATASTORE do
         self.class.get_attributes.each do |node|
           xml.send node.to_s.upcase, resource[node] unless resource[node].nil?
+
+          if node.to_s == "cluster_id" and not resource[node].nil?
+            self.debug "Warning: #{node} specified but datastore will not be added to the cluster; the only change is that the parameter is added to the onedatastore template; call `onecluster adddatastore` to add the datastore to the cluster"
+          end
         end
       end
     end
@@ -62,7 +66,7 @@ Puppet::Type.type(:onedatastore).provide(:cli) do
       return
     end
 
-    self.debug ":self_test defined"
+    self.debug ":self_test defined: running post validation"
 
     [1..3].each do
       if is_status_success?

--- a/lib/puppet/provider/onedatastore/cli.rb
+++ b/lib/puppet/provider/onedatastore/cli.rb
@@ -49,13 +49,8 @@ Puppet::Type.type(:onedatastore).provide(:cli) do
     file.write(tempfile)
     file.close
     self.debug "Adding new datastore using: #{tempfile}"
-    begin
-      onedatastore('create', file.path)
-      post_validate_change
-    rescue Exception => e
-      destroy 
-      raise e
-    end
+    onedatastore('create', file.path)
+    post_validate_change
     file.delete
     
     @property_hash[:ensure] = :present


### PR DESCRIPTION
The first commit removes the rescue block for faulty creation and/or post-validation. The reason is that the rescue block prevents helpful error messages reaching the user.

The second commit adds a warning message to explain that cluster_ids passed to the datastore provider at creation time do not lead to the datastore being added to the cluster specified. This matches the behaviour of the onedatastore tool. As no error is thrown (the intended value appears in updated template after all), the provider throws a warning encouraging the user to call `onecluster adddatastore` instead.