### PR TITLE
removed cluster ID from type onehost

### DIFF
--- a/lib/puppet/type/onehost.rb
+++ b/lib/puppet/type/onehost.rb
@@ -48,9 +48,4 @@ EOS
     newvalues(:'802.1Q', :dummy, :ebtables, :fw, :ovswitch, :vmware)
   end
 
-  newproperty(:cluster_id) do
-    desc "Cluster ID"
-    defaultto :'-1'
-  end
-
 end

--- a/spec/type/onehost_spec.rb
+++ b/spec/type/onehost_spec.rb
@@ -39,11 +39,6 @@ describe res_type do
       @host[:vm_mad].should == :kvm
   end
 
-  it 'should have property :cluster_id' do
-      @host[:cluster_id] = '-1'
-      @host[:cluster_id].should == '-1'
-  end
-
   parameter_tests = {
     :name => {
       :valid => ["test", "foo"],


### PR DESCRIPTION
Removed reference to cluster ID from onehost type to suppress warnings during Puppet rollout.