### PR TITLE
parallel rspec tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rvm:
   - 2.1.2
 language: ruby
 bundler_args: --without development --without integration
-script: "bundle exec rake"
+script: "bundle exec rake parallel_spec"
 env:
   - PUPPET_GEM_VERSION=3.1.1
   - PUPPET_GEM_VERSION=3.2.4

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ else
   gem 'puppet', '< 4', :require => false
 end
 
+gem 'parallel_tests'
+
 # puppet lint plugins
 # https://puppet.community/plugins/#puppet-lint
 gem 'puppet-lint-appends-check',

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'rake'
 require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint'
+require 'parallel_tests/cli'
 
 desc 'Run the tests'
 RSpec::Core::RakeTask.new(:do_test) do |t|
@@ -17,6 +18,13 @@ desc 'Generate the docs'
 RSpec::Core::RakeTask.new(:doc) do |t|
   t.rspec_opts = ['--format', 'documentation']
   t.pattern = 'spec/*/*_spec.rb'
+end
+
+desc "Parallel spec tests"
+task :parallel_spec do
+  Rake::Task[:spec_prep].invoke
+  ParallelTests::CLI.new.run('--type test -t rspec spec/classes spec/provider spec/type'.split)
+  Rake::Task[:spec_clean].invoke
 end
 
 PuppetLint::RakeTask.new(:lint) do |config|

--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,6 +1,5 @@
 --format
-s
+documentation
 --colour
---loadby
 mtime
 --backtrace


### PR DESCRIPTION
make use of parallel rspec testing
- add parallel_tests gem
- wrap spec_prep, spec_standalone, spec_clean into a new rake task
- remove spec.opts which are no longer working
- let travis run the new rake task