### PR TITLE
Fix provider nokogiri dependence

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ The one (short for OpenNebula) module allows to install and manage your OpenNebu
 We support Puppet 3.1.1 on CentOS 6.7 with OpenNebula 4.12.1. 
 You need to add the EPEL repository because the module needs some packages from there.
 
+Note, there is a required package on the oned controller node that is not managed by this module, the gem nokogiri (or the yum package rubygem-nokori).  This can be installed elsewhere in that node's puppet catalog like this:
+
+    package {'rubygem-nokogiri':
+      ensure => installed,
+    } ->
+    class {'::one':}
+
 ### Puppet Module Dependencies
 The ONe-Module needs the following other modules:
 

--- a/lib/puppet/feature/nokogiri.rb
+++ b/lib/puppet/feature/nokogiri.rb
@@ -1,0 +1,1 @@
+Puppet.features.add(:nokogiri, :libs => ["nokogiri"])

--- a/lib/puppet/provider/onecluster/cli.rb
+++ b/lib/puppet/provider/onecluster/cli.rb
@@ -12,9 +12,10 @@
 #
 
 require 'rubygems'
-require 'nokogiri'
+require 'nokogiri' if Puppet.features.nokogiri?
 
 Puppet::Type.type(:onecluster).provide(:cli) do
+  confine :feature => :nokogiri
   desc "onecluster provider"
 
   has_command(:onecluster, "onecluster") do

--- a/lib/puppet/provider/onedatastore/cli.rb
+++ b/lib/puppet/provider/onedatastore/cli.rb
@@ -15,9 +15,10 @@
 #
 
 require 'rubygems'
-require 'nokogiri'
+require 'nokogiri' if Puppet.features.nokogiri?
 
 Puppet::Type.type(:onedatastore).provide(:cli) do
+  confine :feature => :nokogiri
   desc 'onedatastore provider'
 
   has_command(:onedatastore, 'onedatastore') do

--- a/lib/puppet/provider/onehost/cli.rb
+++ b/lib/puppet/provider/onehost/cli.rb
@@ -12,9 +12,10 @@
 #
 
 require 'rubygems'
-require 'nokogiri'
+require 'nokogiri' if Puppet.features.nokogiri?
 
 Puppet::Type.type(:onehost).provide(:cli) do
+  confine :feature => :nokogiri
   desc "onehost provider"
 
   commands(:onehost => "onehost") do

--- a/lib/puppet/provider/oneimage/cli.rb
+++ b/lib/puppet/provider/oneimage/cli.rb
@@ -12,9 +12,10 @@
 #
 
 require 'rubygems'
-require 'nokogiri'
+require 'nokogiri' if Puppet.features.nokogiri?
 
 Puppet::Type.type(:oneimage).provide(:cli) do
+  confine :feature => :nokogiri
   desc "oneimage provider"
 
   has_command(:oneimage, "oneimage") do

--- a/lib/puppet/provider/onesecgroup/cli.rb
+++ b/lib/puppet/provider/onesecgroup/cli.rb
@@ -12,9 +12,10 @@
 #
 
 require 'rubygems'
-require 'nokogiri'
+require 'nokogiri' if Puppet.features.nokogiri?
 
 Puppet::Type.type(:onesecgroup).provide(:cli) do
+  confine :feature => :nokogiri
   desc "onesecgroup provider"
 
   has_command(:onesecgroup, "onesecgroup") do

--- a/lib/puppet/provider/onetemplate/cli.rb
+++ b/lib/puppet/provider/onetemplate/cli.rb
@@ -12,9 +12,10 @@
 #
 
 require 'rubygems'
-require 'nokogiri'
+require 'nokogiri' if Puppet.features.nokogiri?
 
 Puppet::Type.type(:onetemplate).provide(:cli) do
+  confine :feature => :nokogiri
   desc "onetemplate provider"
 
   has_command(:onetemplate, "onetemplate") do

--- a/lib/puppet/provider/onevm/cli.rb
+++ b/lib/puppet/provider/onevm/cli.rb
@@ -12,11 +12,12 @@
 #
 
 require 'rubygems'
-require 'nokogiri'
+require 'nokogiri' if Puppet.features.nokogiri?
 require 'tempfile'
 require 'erb'
 
 Puppet::Type.type(:onevm).provide(:cli) do
+  confine :feature => :nokogiri
   desc "onevm provider"
 
   has_command(:onevm, "onevm") do

--- a/lib/puppet/provider/onevnet/cli.rb
+++ b/lib/puppet/provider/onevnet/cli.rb
@@ -12,9 +12,10 @@
 #
 
 require 'rubygems'
-require 'nokogiri'
+require 'nokogiri' if Puppet.features.nokogiri?
 
 Puppet::Type.type(:onevnet).provide(:cli) do
+  confine :feature => :nokogiri
   desc 'onevnet provider'
 
   has_command(:onevnet, 'onevnet') do

--- a/lib/puppet/provider/onevnet_addressrange/cli.rb
+++ b/lib/puppet/provider/onevnet_addressrange/cli.rb
@@ -14,9 +14,10 @@
 #require 'pry'
 
 require 'rubygems'
-require 'nokogiri'
+require 'nokogiri' if Puppet.features.nokogiri?
 
 Puppet::Type.type(:onevnet_addressrange).provide(:cli) do
+  confine :feature => :nokogiri
   desc "onevnet provider for addressranges"
 
   has_command(:onevnet, "onevnet") do


### PR DESCRIPTION
This fixes a hard dependence on nokogiri being installed on the oned controller node prior to a puppet run being able to run, this error when trying to run puppet:

> 
Error: Could not autoload puppet/provider/onehost/cli: cannot load such file -- nokogiri
...
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run

With the providers confined to the feature, they will load but be non-functional until the package is in place -- this means that the catalog can continue (and can install the package before the providers are run later in the catalog).  Reference http://alcy.github.io/2012/11/21/handling-gem-dependencies-in-custom-puppet-providers/