### PR TITLE
added ci.yml for acceptance tests.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,3 +38,8 @@ end
 
 task :default => [:spec_prep, :lint, :do_test, :spec_clean]
 task :test => [:default]
+
+desc "Run Acceptance tests on CI with multiple nodes"
+  task :ci  do
+    sh('RS_SET=ci bundle exec rake beaker')
+  end

--- a/spec/acceptance/nodesets/ci.yml
+++ b/spec/acceptance/nodesets/ci.yml
@@ -1,0 +1,29 @@
+HOSTS:
+  centos-6-x64-puppet-31:
+    roles:
+      - default
+    platform: el-6-x86_64
+    box : puppetlabs/centos-6.6-64-nocm
+    hypervisor : vagrant
+    puppet_version : 3.1.1
+
+  centos-6-x64-puppet-35:
+    platform: el-6-x86_64
+    box : puppetlabs/centos-6.6-64-nocm
+    hypervisor : vagrant
+    puppet_version : 3.5.1
+    
+  centos-6-x64-puppet-36:
+    platform: el-6-x86_64
+    box : puppetlabs/centos-6.6-64-nocm
+    hypervisor : vagrant
+    puppet_version : 3.6.2
+
+  centos-6-x64-puppet-38:
+    platform: el-6-x86_64
+    box : puppetlabs/centos-6.6-64-nocm
+    hypervisor : vagrant
+    puppet_version : 3.8.3
+
+CONFIG:
+  type: foss

--- a/spec/acceptance/one_spec.rb
+++ b/spec/acceptance/one_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper_acceptance'
 
 describe 'one class' do
+
   describe 'without parameters' do
     it 'should idempotently run' do
       pp = <<-EOS
         class { one: }
       EOS
 
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
+      apply_on_all_hosts(pp)
     end
   end
   describe 'as ONE HEAD' do
@@ -17,27 +17,27 @@ describe 'one class' do
         class { one: oned => true, node => false,}
       EOS
 
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
+      apply_on_all_hosts(pp)
     end
+    hosts.each do |host|
+      describe user('oneadmin') do
+        it { should exist }
+      end
+      describe package('opennebula') do
+        it { should be_installed }
+      end
+      describe service('opennebula') do
+        it { should be_enabled }
+        it { should be_running }
+      end
 
-    describe user('oneadmin') do
-      it { should exist }
-    end
-    describe package('opennebula') do
-      it { should be_installed }
-    end
-    describe service('opennebula') do
-      it { should be_enabled }
-      it { should be_running }
-    end
+      describe package('opennebula-sunstone') do
+        it { should_not be_installed }
+      end
 
-    describe package('opennebula-sunstone') do
-      it { should_not be_installed }
-    end
-
-    describe service('opennebula-sunstone') do
-      it { should_not be_running }
+      describe service('opennebula-sunstone') do
+        it { should_not be_running }
+      end
     end
   end
 
@@ -47,21 +47,21 @@ describe 'one class' do
         class { one: oned => true, sunstone => true, node => false}
       EOS
 
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
+      apply_on_all_hosts(pp)
     end
+    hosts.each do |host|
+      describe package('opennebula-sunstone') do
+        it { should be_installed }
+      end
 
-    describe package('opennebula-sunstone') do
-      it { should be_installed }
-    end
+      describe service('opennebula-sunstone') do
+        it { should be_enabled }
+        it { should be_running }
+      end
 
-    describe service('opennebula-sunstone') do
-      it { should be_enabled }
-      it { should be_running }
-    end
-
-    describe port(9869) do
-      it { is_expected.to be_listening }
+      describe port(9869) do
+        it { is_expected.to be_listening }
+      end
     end
   end
 
@@ -71,14 +71,15 @@ describe 'one class' do
         class { one: node => true }
       EOS
 
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
+      apply_on_all_hosts(pp)
     end
-
-    if fact('osfamily') == 'RedHat'
-      describe package('opennebula-node-kvm') do
-        it { should be_installed }
+    hosts.each do |host|
+      if fact('osfamily') == 'RedHat'
+        describe package('opennebula-node-kvm') do
+          it { should be_installed }
+        end
       end
     end
   end
+
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -3,7 +3,18 @@ require 'pry'
 
 hosts.each do |host|
   # Install Puppet
-  install_puppet
+  # if there is a specific version in the host yml use it - otherwise default to latest < 4.x
+  install_puppet_on(host, {
+    :version => host.host_hash["puppet_version"]
+   })
+end
+
+### helper to use more than 1 host
+def apply_on_all_hosts(pp)
+  hosts.each do |host|
+   apply_manifest_on(host, pp, :catch_failures => true)
+   apply_manifest_on(host, pp, :catch_changes => true)
+  end
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
* reworks spec_helper to support multiple hosts
  with different puppet versions.
* rake task :ci runs tests on all included hosts.
  -> currently: centos 6 with 4 puppet versions