### PR TITLE
Fix onegate endpoint in oned.conf

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,13 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :test do
-  gem 'rake',                    :require => false
+  if RUBY_VERSION < '1.9.3'
+    gem 'rake', '< 11'
+    gem 'retriable', '< 2'
+    gem 'addressable', '< 2.4'
+  else
+    gem 'rake', :require => false
+  end
   gem 'rspec-puppet',            :require => false
   gem 'rspec-puppet-utils',      :require => false
   gem 'puppetlabs_spec_helper',  :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ end
 gem 'puppet-lint-appends-check',
     :git => 'https://github.com/puppet-community/puppet-lint-appends-check.git',
     :require => false
-gem 'puppet-lint-classes_and_types_beginning_with_digits--check',
+gem 'puppet-lint-classes_and_types_beginning_with_digits-check',
     :git => 'https://github.com/puppet-community/puppet-lint-classes_and_types_beginning_with_digits-check.git',
     :require => false
 gem 'puppet-lint-empty_string-check',

--- a/README.md
+++ b/README.md
@@ -229,4 +229,3 @@ How to contribute: [CONTRIBUTING.md](./CONTRIBUTING.md)
 Copyright © 2013 - 2015 [Deutsche Post E-Post Development GmbH](http://epost.de)
 
 Distributed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
-

--- a/README.md
+++ b/README.md
@@ -229,3 +229,4 @@ How to contribute: [CONTRIBUTING.md](./CONTRIBUTING.md)
 Copyright © 2013 - 2015 [Deutsche Post E-Post Development GmbH](http://epost.de)
 
 Distributed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -397,6 +397,7 @@ class one (
   $hook_scripts                   = $one::params::hook_scripts,
   $inherit_datastore_attrs        = $one::params::inherit_datastore_attrs,
   $oned_onegate_ip                = $one::params::oned_onegate_ip,
+  $oned_onegate_endpoint          = $one::params::oned_onegate_endpoint,
   $kickstart_network              = $one::params::kickstart_network,
   $kickstart_partition            = $one::params::kickstart_partition,
   $kickstart_rootpw               = $one::params::kickstart_rootpw,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -122,6 +122,8 @@ class one::params {
 
   # Todo: Use Serviceip from HA-Setup if ha enabled.
   $oned_onegate_ip = hiera('one::oned::onegate::ip', $::ipaddress)
+  # Specify full endpoint if needed (such as if using https proxy)
+  $oned_onegate_endpoint = hiera('one::oned::onegate::endpoint', undef)
 
   # E-POST imaginator parameters
   $kickstart_network         = hiera ('one::node::kickstart::network', undef)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -123,7 +123,7 @@ class one::params {
   # Todo: Use Serviceip from HA-Setup if ha enabled.
   $oned_onegate_ip = hiera('one::oned::onegate::ip', $::ipaddress)
   # Specify full endpoint if needed (such as if using https proxy)
-  $oned_onegate_endpoint = hiera('one::oned::onegate::endpoint', undef)
+  $oned_onegate_endpoint = hiera('one::oned::onegate::endpoint', 'undef')
 
   # E-POST imaginator parameters
   $kickstart_network         = hiera ('one::node::kickstart::network', undef)

--- a/templates/oned.conf.erb
+++ b/templates/oned.conf.erb
@@ -899,8 +899,10 @@ DEFAULT_UMASK = 177
 #   MUST be consistent with the values in onegate-server.conf
 #*******************************************************************************
 
-<% if scope.lookupvar('one::oned_onegate_ip') -%>
-ONEGATE_ENDPOINT = "<%= scope.lookupvar('one::oned_onegate_ip') %>:5030"
+<% if scope.lookupvar('one::oned_onegate_endpoint') -%>
+ONEGATE_ENDPOINT = "<%= scope.lookupvar('one::oned_onegate_endpoint') %>"
+<% elsif scope.lookupvar('one::oned_onegate_ip') -%>
+ONEGATE_ENDPOINT = "http://<%= scope.lookupvar('one::oned_onegate_ip') %>:5030"
 <% else -%>
 #ONEGATE_ENDPOINT = "http://frontend:5030"
 <% end -%>

--- a/templates/oned.conf.erb
+++ b/templates/oned.conf.erb
@@ -899,7 +899,7 @@ DEFAULT_UMASK = 177
 #   MUST be consistent with the values in onegate-server.conf
 #*******************************************************************************
 
-<% if scope.lookupvar('one::oned_onegate_endpoint') -%>
+<% if scope.lookupvar('one::oned_onegate_endpoint') != 'undef' -%>
 ONEGATE_ENDPOINT = "<%= scope.lookupvar('one::oned_onegate_endpoint') %>"
 <% elsif scope.lookupvar('one::oned_onegate_ip') -%>
 ONEGATE_ENDPOINT = "http://<%= scope.lookupvar('one::oned_onegate_ip') %>:5030"

--- a/templates/oned.conf.erb
+++ b/templates/oned.conf.erb
@@ -899,8 +899,8 @@ DEFAULT_UMASK = 177
 #   MUST be consistent with the values in onegate-server.conf
 #*******************************************************************************
 
-<% if scope.lookupvar('one::oned_onedgate_ip') -%>
-ONEGATE_ENDPOINT = "<%= scope.lookupvar('one::oned_onedgate_ip') %>:5030"
+<% if scope.lookupvar('one::oned_onegate_ip') -%>
+ONEGATE_ENDPOINT = "<%= scope.lookupvar('one::oned_onegate_ip') %>:5030"
 <% else -%>
 #ONEGATE_ENDPOINT = "http://frontend:5030"
 <% end -%>


### PR DESCRIPTION
This PR fixes setting ONEGATE_ENDPOINT in oned.conf and also adds a parameter called oned_onegate_endpoint that can be used to override the default "http://<oned_onegate_ip>:5030" if needed (such as if using ssl proxy)