### PR TITLE
newer packages of kvm require an updated version of device-mapper-libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ Create onevnet addressrange
         ulaprefix     => 'fd01:a:b::',        # optional
     }
 
-Attention: onevnet_addressrange uses the title to uniqly identify addressranges among all Virtual Networks.
+Attention: onevnet_addressrange uses the title to uniqly identify address ranges among all Virtual Networks.
 The title will be set as common attribute with the name PUPPET_NAME.
-This means: addressranges which are not set by Puppet will not be visible using puppet resource onevnet_addressrange command.
+This means: address ranges which are not set by Puppet will not be visible using puppet resource onevnet_addressrange command.
 
 
 Create a ONE Datastore

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -205,11 +205,13 @@ class one::params {
     'RedHat': {
       if $::operatingsystemmajrelease == '7' {
         $node_packages = [
+          'device-mapper-libs',
           'opennebula-node-kvm',
           'ipset',
         ]
       } else {
         $node_packages = [
+          'device-mapper-libs',
           'opennebula-node-kvm',
           'python-virtinst',
           'ipset',


### PR DESCRIPTION
on centos. Since the kvm centos package does not resolve this dependency we
require the latest version.