### PR TITLE
use ha_setup param for onegate, oneflow services

### DIFF
--- a/manifests/oned/oneflow/service.pp
+++ b/manifests/oned/oneflow/service.pp
@@ -17,9 +17,18 @@
 # http://www.apache.org/licenses/LICENSE-2.0.html
 #
 class one::oned::oneflow::service {
+
+  if ($one::ha_setup) {
+    $oneflow_enable = false
+    $oneflow_ensure = undef
+  } else {
+    $oneflow_enable = true
+    $oneflow_ensure = running
+  }
+
   service {'opennebula-flow':
-    ensure  => running,
-    enable  => true,
+    ensure  => $oneflow_ensure,
+    enable  => $oneflow_enable,
     require => Service['opennebula'],
   }
 }

--- a/manifests/oned/onegate/service.pp
+++ b/manifests/oned/onegate/service.pp
@@ -17,9 +17,18 @@
 # http://www.apache.org/licenses/LICENSE-2.0.html
 #
 class one::oned::onegate::service {
+
+  if ($one::ha_setup) {
+    $onegate_enable = false
+    $onegate_ensure = undef
+  } else {
+    $onegate_enable = true
+    $onegate_ensure = running
+  }
+
   service {'opennebula-gate':
-    ensure  => running,
-    enable  => true,
+    ensure  => $onegate_ensure,
+    enable  => $onegate_enable,
     require => Service['opennebula'],
   }
 }


### PR DESCRIPTION
This allows to not manage the service status for onegate and oneflow, in
case using ha setup. (This is the same as already being done for
opennebula service itself).