### PR TITLE
make locations for sudoer rules configurable

### DIFF
--- a/manifests/compute_node/config.pp
+++ b/manifests/compute_node/config.pp
@@ -33,7 +33,7 @@ class one::compute_node::config (
   $libvirtd_source         = $one::libvirtd_source,
   $libvirtd_srv            = $one::libvirtd_srv,
   $oneadmin_sudoers_file   = $one::oneadmin_sudoers_file,
-  $sudoers_imaginator_file = $one::sudoers_imaginator_file
+  $imaginator_sudoers_file = $one::imaginator_sudoers_file
 ){
 
   validate_string ($debian_mirror_url)
@@ -75,7 +75,7 @@ class one::compute_node::config (
     mode   => '0440',
   } ->
 
-  file { $sudoers_imaginator_file:
+  file { $imaginator_sudoers_file:
     ensure => file,
     source => 'puppet:///modules/one/sudoers_imaginator',
     owner  => 'root',

--- a/manifests/compute_node/config.pp
+++ b/manifests/compute_node/config.pp
@@ -20,18 +20,20 @@
 # http://www.apache.org/licenses/LICENSE-2.0.html
 #
 class one::compute_node::config (
-  $networkconfig     = $one::kickstart_network,
-  $partitions        = $one::kickstart_partition,
-  $rootpw            = $one::kickstart_rootpw,
-  $data              = $one::kickstart_data,
-  $kickstart_tmpl    = $one::kickstart_tmpl,
-  $preseed_data      = $one::preseed_data,
-  $ohd_deb_repo      = $one::preseed_ohd_deb_repo,
-  $debian_mirror_url = $one::preseed_debian_mirror_url,
-  $preseed_tmpl      = $one::preseed_tmpl,
-  $libvirtd_cfg      = $one::libvirtd_cfg,
-  $libvirtd_source   = $one::libvirtd_source,
-  $libvirtd_srv      = $one::libvirtd_srv
+  $networkconfig           = $one::kickstart_network,
+  $partitions              = $one::kickstart_partition,
+  $rootpw                  = $one::kickstart_rootpw,
+  $data                    = $one::kickstart_data,
+  $kickstart_tmpl          = $one::kickstart_tmpl,
+  $preseed_data            = $one::preseed_data,
+  $ohd_deb_repo            = $one::preseed_ohd_deb_repo,
+  $debian_mirror_url       = $one::preseed_debian_mirror_url,
+  $preseed_tmpl            = $one::preseed_tmpl,
+  $libvirtd_cfg            = $one::libvirtd_cfg,
+  $libvirtd_source         = $one::libvirtd_source,
+  $libvirtd_srv            = $one::libvirtd_srv,
+  $oneadmin_sudoers_file   = $one::oneadmin_sudoers_file,
+  $sudoers_imaginator_file = $one::sudoers_imaginator_file
 ){
 
   validate_string ($debian_mirror_url)
@@ -65,7 +67,7 @@ class one::compute_node::config (
     source => 'puppet:///modules/one/udev-kvm-rules',
   } ->
 
-  file { '/etc/sudoers.d/10_oneadmin':
+  file { $oneadmin_sudoers_file:
     ensure => file,
     source => 'puppet:///modules/one/oneadmin_sudoers',
     owner  => 'root',
@@ -73,7 +75,7 @@ class one::compute_node::config (
     mode   => '0440',
   } ->
 
-  file { '/etc/sudoers.d/20_imaginator':
+  file { $sudoers_imaginator_file:
     ensure => file,
     source => 'puppet:///modules/one/sudoers_imaginator',
     owner  => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -291,6 +291,10 @@
 # $libvirtd_cfg 
 # $libvirtd_source 
 # $rubygems 
+# $oneadmin_sudoers_file - default '/etc/sudoers.d/10_oneadmin'
+#   where to place the file with the oneadmin sudoer rules
+# $sudoers_imaginator_file - default '/etc/sudoers.d/20_imaginator'
+#   where to place the file with the imaginator sudoer rules
 #
 # ==== Environment specific configuration
 #
@@ -426,6 +430,8 @@ class one (
   $libvirtd_srv                   = $one::params::libvirtd_srv,
   $libvirtd_cfg                   = $one::params::libvirtd_cfg,
   $libvirtd_source                = $one::params::libvirtd_source,
+  $oneadmin_sudoers_file          = $one::params::oneadmin_sudoers_file,
+  $sudoers_imaginator_file        = $one::params::sudoers_imaginator_file,
   $kvm_driver_emulator            = $one::params::kvm_driver_emulator,
   $kvm_driver_nic_attrs           = $one::params::kvm_driver_nic_attrs,
   $rubygems                       = $one::params::rubygems,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -455,6 +455,9 @@ class one (
 
   # Data Validation
 
+  validate_absolute_path($oneadmin_sudoers_file)
+  validate_absolute_path($imaginator_sudoers_file)
+
   # the priv key is mandatory on the head.
   if ($ssh_pub_key == undef) {
     fail('The ssh_pub_key is mandatory for all nodes')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -293,7 +293,7 @@
 # $rubygems 
 # $oneadmin_sudoers_file - default '/etc/sudoers.d/10_oneadmin'
 #   where to place the file with the oneadmin sudoer rules
-# $sudoers_imaginator_file - default '/etc/sudoers.d/20_imaginator'
+# $imaginator_sudoers_file - default '/etc/sudoers.d/20_imaginator'
 #   where to place the file with the imaginator sudoer rules
 #
 # ==== Environment specific configuration
@@ -431,7 +431,7 @@ class one (
   $libvirtd_cfg                   = $one::params::libvirtd_cfg,
   $libvirtd_source                = $one::params::libvirtd_source,
   $oneadmin_sudoers_file          = $one::params::oneadmin_sudoers_file,
-  $sudoers_imaginator_file        = $one::params::sudoers_imaginator_file,
+  $imaginator_sudoers_file        = $one::params::imaginator_sudoers_file,
   $kvm_driver_emulator            = $one::params::kvm_driver_emulator,
   $kvm_driver_nic_attrs           = $one::params::kvm_driver_nic_attrs,
   $rubygems                       = $one::params::rubygems,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -165,6 +165,10 @@ class one::params {
   $default_device_prefix       = hiera ('one::oned::default_device_prefix', 'hd')
   $default_cdrom_device_prefix = hiera ('one::oned::default_cdrom_device_prefix', 'hd')
 
+  # Where to place the sudo rule files
+  $oneadmin_sudoers_file   = '/etc/sudoers.d/10_oneadmin'
+  $sudoers_imaginator_file = '/etc/sudoers.d/20_imaginator'
+
   # OS specific params for nodes
   case $::osfamily {
     'RedHat': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -167,7 +167,7 @@ class one::params {
 
   # Where to place the sudo rule files
   $oneadmin_sudoers_file   = '/etc/sudoers.d/10_oneadmin'
-  $sudoers_imaginator_file = '/etc/sudoers.d/20_imaginator'
+  $imaginator_sudoers_file = '/etc/sudoers.d/20_imaginator'
 
   # OS specific params for nodes
   case $::osfamily {

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,7 @@
     }
    ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": "> 2.2.0" },
+    { "name": "puppetlabs/stdlib", "version_requirement": "> 2.3.0" },
     { "name": "puppetlabs/apt", "version_requirement": "< 2.0.0" },
     { "name": "puppetlabs/inifile", "version_requirement": "> 1.4.0" }
   ]

--- a/spec/classes/one__compute_node__config_spec.rb
+++ b/spec/classes/one__compute_node__config_spec.rb
@@ -10,15 +10,15 @@ describe 'one::compute_node::config', :type => :class do
           :debian_mirror_url => 'http://ftp.de.debian.org/debian',
           :preseed_data => {'does' => 'not_matter'},
           :libvirtd_cfg => '/etc/some/libvirt/config',
-          :oneadmin_sudoers_file => '/etc/sudoers.d/10_oneadmin',
-          :sudoers_imaginator_file => '/etc/sudoers.d/20_imaginator'
+          :oneadmin_sudoers_file => '/etc/test-sudoers.d/10_oneadmin',
+          :imaginator_sudoers_file => '/etc/test-sudoers.d/20_imaginator'
       } }
       it { should contain_class('one::compute_node::config') }
       it { should contain_file('/etc/libvirt/libvirtd.conf') }
       it { should contain_file('/etc/some/libvirt/config') }
       it { should contain_file('/etc/udev/rules.d/80-kvm.rules') }
-      it { should contain_file('/etc/sudoers.d/10_oneadmin') }
-      it { should contain_file('/etc/sudoers.d/20_imaginator') }
+      it { should contain_file('/etc/test-sudoers.d/10_oneadmin') }
+      it { should contain_file('/etc/test-sudoers.d/20_imaginator') }
       if f[:osfamily] == 'Debian'
         it { should contain_file('polkit-opennebula') \
             .with_path('/var/lib/polkit-1/localauthority/50-local.d/50-org.libvirt.unix.manage-opennebula.pkla')

--- a/spec/classes/one__compute_node__config_spec.rb
+++ b/spec/classes/one__compute_node__config_spec.rb
@@ -9,7 +9,9 @@ describe 'one::compute_node::config', :type => :class do
       let(:params) { {
           :debian_mirror_url => 'http://ftp.de.debian.org/debian',
           :preseed_data => {'does' => 'not_matter'},
-          :libvirtd_cfg => '/etc/some/libvirt/config'
+          :libvirtd_cfg => '/etc/some/libvirt/config',
+          :oneadmin_sudoers_file => '/etc/sudoers.d/10_oneadmin',
+          :sudoers_imaginator_file => '/etc/sudoers.d/20_imaginator'
       } }
       it { should contain_class('one::compute_node::config') }
       it { should contain_file('/etc/libvirt/libvirtd.conf') }

--- a/spec/classes/one_parameter_validation_spec.rb
+++ b/spec/classes/one_parameter_validation_spec.rb
@@ -81,6 +81,14 @@ describe 'one', :type => :class do
           end
         end
       end
+      %w<oneadmin_sudoers_file imaginator_sudoers_file>.each do |param|
+        context "given a non-absolute path for #{param}" do
+          let(:params) {{ param => "relative/path/to/#{param}" }}
+          it do
+            is_expected.to compile.and_raise_error(/"relative\/path\/to\/#{param}" is not an absolute path/)
+          end
+        end
+      end
       context "validating ssh keys" do
         let(:hiera_config) { nil }
         context "missing the mandatory pubkey" do


### PR DESCRIPTION
when placing the sudo rule files for oneadmin and imaginator the module assumed default locations
which don't work out in our case. Added a configuration switch for each file location.