### PR TITLE
Fix parameter validation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -447,6 +447,47 @@ class one (
   $one_version                    = $one::params::one_version,
 ) inherits one::params {
 
+  # Data Validation
+
+  # the priv key is mandatory on the head.
+  if ($ssh_pub_key == undef) {
+    fail('The ssh_pub_key is mandatory for all nodes')
+  }
+  validate_string($ssh_pub_key)
+  if (false == $node) {
+    if ($ssh_priv_key_param == undef) {
+      fail('The ssh_priv_key_param is mandatory for the head')
+    }
+    validate_string($ssh_priv_key_param)
+    $ssh_priv_key = $ssh_priv_key_param
+  }
+
+  # ensure xmlrpctuning is in string
+  validate_string($xmlrpc_maxconn, $xmlrpc_maxconn_backlog, $xmlrpc_keepalive_timeout, $xmlrpc_keepalive_max_conn, $xmlrpc_timeout)
+
+  # ensure INHERIT attrs is array
+  if ($inherit_datastore_attrs) {
+    validate_array($inherit_datastore_attrs)
+  }
+
+  if ($hook_scripts_pkgs) {
+    validate_array($hook_scripts_pkgs)
+  }
+
+  if ($hook_scripts) {
+    validate_hash($hook_scripts)
+    $vm_hook_scripts = $hook_scripts['VM'] # lint:ignore:variable_contains_upcase
+
+    if ($vm_hook_scripts) {
+      validate_hash($vm_hook_scripts)
+    }
+
+    $host_hook_scripts = $hook_scripts['HOST'] # lint:ignore:variable_contains_upcase
+    if ($host_hook_scripts) {
+      validate_hash($host_hook_scripts)
+    }
+  }
+
   # check if version greater than or equal to 4.14 (used in templates)
   if ( versioncmp($one_version, '4.14') >= 0 ) {
     $version_gte_4_14 = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -165,41 +165,6 @@ class one::params {
   $default_device_prefix       = hiera ('one::oned::default_device_prefix', 'hd')
   $default_cdrom_device_prefix = hiera ('one::oned::default_cdrom_device_prefix', 'hd')
 
-  # Data Validation
-
-  # the priv key is mandatory on the head.
-  validate_string($ssh_pub_key)
-  if (!$one::node) {
-    validate_string($ssh_priv_key_param)
-    $ssh_priv_key = $ssh_priv_key_param
-  }
-
-  # ensure xmlrpctuning is in string
-  validate_string($xmlrpc_maxconn, $xmlrpc_maxconn_backlog, $xmlrpc_keepalive_timeout, $xmlrpc_keepalive_max_conn, $xmlrpc_timeout)
-
-  # ensure INHERIT attrs is array
-  if ($inherit_datastore_attrs) {
-    validate_array($inherit_datastore_attrs)
-  }
-
-  if ($hook_scripts_pkgs) {
-    validate_array($hook_scripts_pkgs)
-  }
-
-  if ($hook_scripts) {
-    validate_hash($hook_scripts)
-    $vm_hook_scripts = $hook_scripts['VM'] # lint:ignore:variable_contains_upcase
-
-    if ($vm_hook_scripts) {
-      validate_hash($vm_hook_scripts)
-    }
-
-    $host_hook_scripts = $hook_scripts['HOST'] # lint:ignore:variable_contains_upcase
-    if ($host_hook_scripts) {
-      validate_hash($host_hook_scripts)
-    }
-  }
-
   # OS specific params for nodes
   case $::osfamily {
     'RedHat': {

--- a/spec/classes/one_parameter_validation_spec.rb
+++ b/spec/classes/one_parameter_validation_spec.rb
@@ -1,0 +1,126 @@
+# validation for the ssh key parameters is tested in a dedicated spec
+# since that spec requires an empty hiera fixture
+require 'spec_helper'
+
+hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+
+describe 'one', :type => :class do
+  OS_FACTS.each do |f|
+    context "On #{f[:operatingsystem]} #{f[:operatingsystemmajrelease]}" do
+      let(:facts) { f }
+      %w<xmlrpc_maxconn xmlrpc_maxconn_backlog xmlrpc_keepalive_timeout xmlrpc_keepalive_max_conn xmlrpc_timeout>.each do |param|
+        context "given a non-string value for #{param}" do
+          let(:params) {
+            { param => ["foo", "bar"] }
+          }
+          it do
+            is_expected.to compile.and_raise_error(/is not a string.  It looks to be a Array at/)
+          end
+        end
+        context "given a string value for #{param}" do
+          let(:params) {
+            { param => "foobar" }
+          }
+          it do
+            is_expected.to compile
+          end
+        end
+      end
+      %w<inherit_datastore_attrs hook_scripts_pkgs>.each do |param|
+        context "given a non-array value for #{param}" do
+          let(:params) {
+            {
+              param => "string"
+            }
+          }
+          it do
+            is_expected.to compile.and_raise_error(/is not an Array.  It looks to be a String at/)
+          end
+        end
+        context "given an array value for #{param}" do
+          let(:params) {
+            {
+              param => ["foo", "bar"]
+            }
+          }
+          it do
+            is_expected.to compile
+          end
+        end
+      end
+      context "validating hook scripts" do
+        context "given a non-hash value for hook_scripts" do
+          let(:params) {{ "hook_scripts" => "string"  }}
+          it do
+            is_expected.to compile.and_raise_error(/is not a Hash.  It looks to be a String at/)
+          end
+        end
+        context "given a non-hash value for vm_hook_scripts" do
+          let(:params) {{ "hook_scripts" => { "VM" => "string"}  }}
+          it do
+            is_expected.to compile.and_raise_error(/is not a Hash.  It looks to be a String at/)
+          end
+        end
+        context "given a non-hash value for host_hook_scripts" do
+          let(:params) {{ "hook_scripts" => { "HOST" => "string"}  }}
+          it do
+            is_expected.to compile.and_raise_error(/is not a Hash.  It looks to be a String at/)
+          end
+        end
+        context "given the expeted format for hook_scripts" do
+          let(:params) do
+             {
+               "hook_scripts" => {
+                 "HOST" => {"foo" => "bar"},
+                 "VM"   => {"foo" => "bar"}
+               }
+             }
+          end
+          it do
+            is_expected.to compile
+          end
+        end
+      end
+      context "validating ssh keys" do
+        let(:hiera_config) { nil }
+        context "missing the mandatory pubkey" do
+          let(:params) {{}}
+          it do
+            is_expected.to compile.and_raise_error(/The ssh_pub_key is mandatory for all nodes/)
+          end
+        end
+        context "passing the mandatory pubkey" do
+          let(:params) {{
+            "ssh_pub_key" => 'ssh pub key'
+          }}
+          it do
+            is_expected.to compile
+          end
+        end
+        context "missing the mandatory private key for one::head" do
+          let(:params) do
+            {
+              "node"        => false,
+              "ssh_pub_key" => 'ssh pub key'
+            }
+          end
+          it do
+            is_expected.to compile.and_raise_error(/The ssh_priv_key_param is mandatory for the head/)
+          end
+        end
+        context "passing the mandatory private key for one::head" do
+          let(:params) do
+            {
+              "node"               => false,
+              "ssh_pub_key"        => 'ssh pub key',
+              "ssh_priv_key_param" => "ssh-dsa priv key"
+            }
+          end
+          it do
+            is_expected.to compile
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
parameter validation does not take place for parameters that are passed as parameters to the `one` class. 

In addition, no check takes place that ssh keys are passed at all. We only check that a key that is passed is a string, the undef case remains unhandled.

The first commit adds a test suite to demonstrate the actual issue.