### PR TITLE
pruned some ruby versions from the travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,8 @@ cache: bundler
 
 rvm:
   - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
-  - 2.1.1
-  - 2.1.2
   - 2.1.7
 language: ruby
 bundler_args: --without development --without integration
@@ -31,28 +28,12 @@ matrix:
       env: PUPPET_GEM_VERSION=4.2.2
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION=4.4.2
-    - rvm: 1.9.2
-      env: PUPPET_GEM_VERSION=4.2.2
-    - rvm: 1.9.2
-      env: PUPPET_GEM_VERSION=4.4.2
     - rvm: 1.9.3
       env: PUPPET_GEM_VERSION=4.2.2
     - rvm: 1.9.3
       env: PUPPET_GEM_VERSION=4.4.2
     - rvm: 2.0.0
       env: PUPPET_GEM_VERSION=3.1.1
-    - rvm: 2.1.1
-      env: PUPPET_GEM_VERSION=3.1.1
-    - rvm: 2.1.1
-      env: PUPPET_GEM_VERSION=3.2.4
-    - rvm: 2.1.1
-      env: PUPPET_GEM_VERSION=3.3.2
-    - rvm: 2.1.2
-      env: PUPPET_GEM_VERSION=3.1.1
-    - rvm: 2.1.2
-      env: PUPPET_GEM_VERSION=3.2.4
-    - rvm: 2.1.2
-      env: PUPPET_GEM_VERSION=3.3.2
     - rvm: 2.1.7
       env: PUPPET_GEM_VERSION=3.1.1
     - rvm: 2.1.7


### PR DESCRIPTION
We're testing multiple ruby minor versions that are mostly identical with other ruby minor versions. This increases build times with little benefit, so we're pruning the set of ruby versions to one per major.

* removed ruby 1.9.2, should be identical with 1.9.3
* removed ruby 2.1.1, 2.1.2, should be identical with 2.1.7