### PR TITLE
onedatastore safe_dirs shouldn't be an array

### DIFF
--- a/lib/puppet/type/onedatastore.rb
+++ b/lib/puppet/type/onedatastore.rb
@@ -90,8 +90,8 @@ Puppet::Type.newtype(:onedatastore) do
     desc 'Temporary scratch space. Must be big enough to store raw image size plus sparse version'
   end
 
-  newproperty(:safe_dirs, :array_matching => :all) do
-    desc 'Array of safe directories'
+  newproperty(:safe_dirs) do
+    desc 'List of safe directories, space separated'
   end
 
 


### PR DESCRIPTION
...should be a space separated list

This fixes an issue where modifying safe_dirs results in an error from the provider:

`Error: /Stage[main]/Main/Onedatastore[cephds]: Could not evaluate: Execution of '/usr/bin/onedatastore update cephds /tmp/onedatastore-cephds20161208-13878-9oyenf --append' returned 255: [DatastoreUpdateTemplate] Cannot update template. Parse error: syntax error, unexpected VARIABLE, expecting EQUAL or EQUAL_EMPTY at line 6, columns 90:94`

.. which is caused by this line in the nebula datastore template:

`SAFE_DIRS = "["/tmp/dir1 /tmp/dir1"]"`

should be

`SAFE_DIRS = "/tmp/dir1 /tmp/dir2"`

This is fixed by making safe_dirs no longer an array, and specifying as a space separated list (similar to ceph_host and bridge_list)