### PR TITLE
add static cpu flag support for kvm

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -443,6 +443,7 @@ class one (
   $imaginator_sudoers_file        = $one::params::imaginator_sudoers_file,
   $kvm_driver_emulator            = $one::params::kvm_driver_emulator,
   $kvm_driver_nic_attrs           = $one::params::kvm_driver_nic_attrs,
+  $kvm_driver_raw_attrs           = $one::params::kvm_driver_raw_attrs,
   $rubygems                       = $one::params::rubygems,
   $sched_interval                 = $one::params::sched_interval,
   $sched_max_vm                   = $one::params::sched_max_vm,

--- a/manifests/oned/config.pp
+++ b/manifests/oned/config.pp
@@ -52,6 +52,7 @@ class one::oned::config(
   $sched_log_debug_level       = $one::sched_log_debug_level,
   $kvm_driver_emulator         = $one::kvm_driver_emulator,
   $kvm_driver_nic_attrs        = $one::kvm_driver_nic_attrs,
+  $kvm_driver_raw_attrs        = $one::kvm_driver_raw_attrs,
   $datastore_capacity_check    = $one::datastore_capacity_check,
   $default_image_type          = $one::default_image_type,
   $default_device_prefix       = $one::default_device_prefix,
@@ -143,6 +144,16 @@ class one::oned::config(
       path    => '/etc/one/vmm_exec/vmm_exec_kvm.conf',
       setting => 'NIC',
       value   => $kvm_driver_nic_attrs,
+    }
+  }
+
+  if $kvm_driver_raw_attrs != 'undef' {
+    ini_setting{ 'set_kvm_driver_raw':
+      ensure  => present,
+      section => '',
+      path    => '/etc/one/vmm_exec/vmm_exec_kvm.conf',
+      setting => 'RAW',
+      value   => $kvm_driver_raw_attrs,
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -78,6 +78,7 @@ class one::params {
   # OpenNebula KVM driver parameters
   $kvm_driver_emulator       = hiera ('one::oned::kvm_driver_emulator', 'undef')
   $kvm_driver_nic_attrs      = hiera ('one::oned::kvm_driver_nic_attrs', 'undef')
+  $kvm_driver_raw_attrs      = hiera ('one::oned::kvm_driver_raw_attrs', 'undef')
 
   # Sunstone configuration parameters
   $sunstone_listen_ip        = hiera('one::oned::sunstone_listen_ip', '127.0.0.1')


### PR DESCRIPTION
This will enable all cpu flags for kvm, i.e. aes-support.
