### PR TITLE
Fix onevnet addressrange cli

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,6 +6,8 @@ fixtures:
         apt:
           repo: "https://github.com/puppetlabs/puppetlabs-apt.git"
           ref: "1.8.0"
-        inifile: "https://github.com/puppetlabs/puppetlabs-inifile"
+        inifile:
+          repo: "https://github.com/puppetlabs/puppetlabs-inifile"
+          ref: "2.1.0"
     symlinks:
         one: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ Create onevnet addressrange
         onevnet_name  => '<name>',            # this has to be an existing onevnet - will be autorequired if declared
         ar_id         => '<INT>',             # read only value
         protocol      => ip4 | ip6 | ip4_6 | ether,
-        size          => '10',
+        ip_size       => '10',
         mac           => '02:00:0a:00:00:96', # optional
         # attributes for ip4 and ip4_6:
-        ip            => '10.0.2.20'
+        ip_start      => '10.0.2.20'
         # attributes for ip6:
         globalprefix  => '2001:a::',          # optional
         ulaprefix     => 'fd01:a:b::',        # optional

--- a/lib/puppet/provider/onevnet_addressrange/cli.rb
+++ b/lib/puppet/provider/onevnet_addressrange/cli.rb
@@ -53,7 +53,7 @@ Puppet::Type.type(:onevnet_addressrange).provide(:cli) do
 
   # Destroy a network using onevnet delete
   def destroy
-    onevnet('rmar', resource[:onevnet_name], resource[:ar_id])
+    onevnet('rmar', resource[:onevnet_name], @property_hash[:ar_id])
     @property_hash.clear
   end
 
@@ -109,13 +109,12 @@ Puppet::Type.type(:onevnet_addressrange).provide(:cli) do
         end
       end
     }.map{|a| "#{a[0]} = #{a[1]}," unless a.nil? }.join("\n")
-    file << "AR_ID = #{resource[:ar_id]}" unless resource[:ar_id].nil?
+    file << "AR_ID = #{@property_hash[:ar_id]}" unless @property_hash[:ar_id].nil?
     file << ']'
     file.close
     self.debug(IO.read file.path)
-    self.debug(@property_hash)
-    unless @property_hash.empty? or resource[:ar_id].nil? or not defined? resource[:ar_id]
-      onevnet('updatear', resource[:onevnet_name], resource[:ar_id], file.path)
+    unless @property_hash.empty? or @property_hash[:ar_id].nil?
+      onevnet('updatear', resource[:onevnet_name], @property_hash[:ar_id], file.path)
     end
     file.delete
   end


### PR DESCRIPTION
The onevnet_addressrange provider was not working correcty, it couldn't delete or change existing AR entries. The reason was, resource instead of property_hash was used.
Both issues are fixed now.

At the same time I updated the readme to use the correct property names.